### PR TITLE
Remove mentions of the privacy of the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # :house_with_garden: monolib
 
-A **private** monorepo with **public**ly published single-file JavaScript utils that we can re-use in our different projects.
+An internal monorepo with publicly published single-file JavaScript utils that we can re-use in our different projects.
 
 To many small functions that just don't belong, it's the place they call home.
 

--- a/packages/abbr/README.md
+++ b/packages/abbr/README.md
@@ -1,3 +1,3 @@
 > Even though this module is publicly accessible, we do not recommend using it in projects outside of [Transloadit](https://transloadit.com). We won't make any guarantees about its workings and can change things at any time, we won't adhere strictly to SemVer.
 
-> This module is maintained from a private mono repo called [monolib](https://github.com/transloadit/monolib).
+> This module is maintained from a monorepo called [monolib](https://github.com/transloadit/monolib).

--- a/packages/analyze-step/README.md
+++ b/packages/analyze-step/README.md
@@ -1,3 +1,3 @@
 > Even though this module is publicly accessible, we do not recommend using it in projects outside of [Transloadit](https://transloadit.com). We won't make any guarantees about its workings and can change things at any time, we won't adhere strictly to SemVer.
 
-> This module is maintained from a private mono repo called [monolib](https://github.com/transloadit/monolib).
+> This module is maintained from a monorepo called [monolib](https://github.com/transloadit/monolib).

--- a/packages/enrich-tweet/README.md
+++ b/packages/enrich-tweet/README.md
@@ -1,3 +1,3 @@
 > Even though this module is publicly accessible, we do not recommend using it in projects outside of [Transloadit](https://transloadit.com). We won't make any guarantees about its workings and can change things at any time, we won't adhere strictly to SemVer.
 
-> This module is maintained from a private mono repo called [monolib](https://github.com/transloadit/monolib).
+> This module is maintained from a monorepo called [monolib](https://github.com/transloadit/monolib).

--- a/packages/file-exists/README.md
+++ b/packages/file-exists/README.md
@@ -1,3 +1,3 @@
 > Even though this module is publicly accessible, we do not recommend using it in projects outside of [Transloadit](https://transloadit.com). We won't make any guarantees about its workings and can change things at any time, we won't adhere strictly to SemVer.
 
-> This module is maintained from a private mono repo called [monolib](https://github.com/transloadit/monolib).
+> This module is maintained from a monorepo called [monolib](https://github.com/transloadit/monolib).

--- a/packages/format-duration-ms/README.md
+++ b/packages/format-duration-ms/README.md
@@ -1,3 +1,3 @@
 > Even though this module is publicly accessible, we do not recommend using it in projects outside of [Transloadit](https://transloadit.com). We won't make any guarantees about its workings and can change things at any time, we won't adhere strictly to SemVer.
 
-> This module is maintained from a private mono repo called [monolib](https://github.com/transloadit/monolib).
+> This module is maintained from a monorepo called [monolib](https://github.com/transloadit/monolib).

--- a/packages/post/README.md
+++ b/packages/post/README.md
@@ -1,6 +1,6 @@
 > Even though this module is publicly accessible, we do not recommend using it in projects outside of [Transloadit](https://transloadit.com). We won't make any guarantees about its workings and can change things at any time, we won't adhere strictly to SemVer.
 
-> This module is maintained from a private mono repo called [monolib](https://github.com/transloadit/monolib).
+> This module is maintained from a monorepo called [monolib](https://github.com/transloadit/monolib).
 
 
 ## Install

--- a/packages/prettier-bytes/README.md
+++ b/packages/prettier-bytes/README.md
@@ -1,6 +1,6 @@
 > Even though this module is publicly accessible, we do not recommend using it in projects outside of [Transloadit](https://transloadit.com). We won't make any guarantees about its workings and can change things at any time, we won't adhere strictly to SemVer.
 
-> This module is maintained from a private mono repo called [monolib](https://github.com/transloadit/monolib).
+> This module is maintained from a monorepo called [monolib](https://github.com/transloadit/monolib).
 
 Adapted from <https://github.com/Flet/prettier-bytes/>
 Changing 1000 bytes to 1024, so we can keep uppercase KB vs kB

--- a/packages/slugify/README.md
+++ b/packages/slugify/README.md
@@ -1,3 +1,3 @@
 > Even though this module is publicly accessible, we do not recommend using it in projects outside of [Transloadit](https://transloadit.com). We won't make any guarantees about its workings and can change things at any time, we won't adhere strictly to SemVer.
 
-> This module is maintained from a private mono repo called [monolib](https://github.com/transloadit/monolib).
+> This module is maintained from a monorepo called [monolib](https://github.com/transloadit/monolib).

--- a/packages/sort-assembly/README.md
+++ b/packages/sort-assembly/README.md
@@ -1,3 +1,3 @@
 > Even though this module is publicly accessible, we do not recommend using it in projects outside of [Transloadit](https://transloadit.com). We won't make any guarantees about its workings and can change things at any time, we won't adhere strictly to SemVer.
 
-> This module is maintained from a private mono repo called [monolib](https://github.com/transloadit/monolib).
+> This module is maintained from a monorepo called [monolib](https://github.com/transloadit/monolib).

--- a/packages/sort-object-by-prio/README.md
+++ b/packages/sort-object-by-prio/README.md
@@ -1,3 +1,3 @@
 > Even though this module is publicly accessible, we do not recommend using it in projects outside of [Transloadit](https://transloadit.com). We won't make any guarantees about its workings and can change things at any time, we won't adhere strictly to SemVer.
 
-> This module is maintained from a private mono repo called [monolib](https://github.com/transloadit/monolib).
+> This module is maintained from a monorepo called [monolib](https://github.com/transloadit/monolib).

--- a/packages/sort-object/README.md
+++ b/packages/sort-object/README.md
@@ -1,3 +1,3 @@
 > Even though this module is publicly accessible, we do not recommend using it in projects outside of [Transloadit](https://transloadit.com). We won't make any guarantees about its workings and can change things at any time, we won't adhere strictly to SemVer.
 
-> This module is maintained from a private mono repo called [monolib](https://github.com/transloadit/monolib).
+> This module is maintained from a monorepo called [monolib](https://github.com/transloadit/monolib).

--- a/packages/sort-result-meta/README.md
+++ b/packages/sort-result-meta/README.md
@@ -1,3 +1,3 @@
 > Even though this module is publicly accessible, we do not recommend using it in projects outside of [Transloadit](https://transloadit.com). We won't make any guarantees about its workings and can change things at any time, we won't adhere strictly to SemVer.
 
-> This module is maintained from a private mono repo called [monolib](https://github.com/transloadit/monolib).
+> This module is maintained from a monorepo called [monolib](https://github.com/transloadit/monolib).

--- a/packages/sort-result/README.md
+++ b/packages/sort-result/README.md
@@ -1,3 +1,3 @@
 > Even though this module is publicly accessible, we do not recommend using it in projects outside of [Transloadit](https://transloadit.com). We won't make any guarantees about its workings and can change things at any time, we won't adhere strictly to SemVer.
 
-> This module is maintained from a private mono repo called [monolib](https://github.com/transloadit/monolib).
+> This module is maintained from a monorepo called [monolib](https://github.com/transloadit/monolib).

--- a/template-package/README.md
+++ b/template-package/README.md
@@ -1,3 +1,3 @@
 > Even though this module is publicly accessible, we do not recommend using it in projects outside of [Transloadit](https://transloadit.com). We won't make any guarantees about its workings and can change things at any time, we won't adhere strictly to SemVer.
 
-> This module is maintained from a private mono repo called [monolib](https://github.com/transloadit/monolib).
+> This module is maintained from a monorepo called [monolib](https://github.com/transloadit/monolib).


### PR DESCRIPTION
It's not actually private, and intentionally so. Maybe some nice person
could run into one of these modules on npm, and conclude that the repo
is accidentally public. If they're very nice they may even contact us to
warn us about it. To save that hypothetical person some time, these
changes make it clear(er) that the repo is internal but not private.