### PR TITLE
Latest `trigger-pager` release broken

### DIFF
--- a/packages/trigger-pager/package.json
+++ b/packages/trigger-pager/package.json
@@ -11,7 +11,7 @@
     "url": "git://github.com/transloadit/monolib.git",
     "directory": "packages/trigger-pager"
   },
-  "main": "./triggerPager.js",
+  "main": "./dist/triggerPager.js",
   "dependencies": {
     "@pagerduty/pdjs": "^2.2.4"
   }


### PR DESCRIPTION
Looks like the latest release of `trigger-pager` is broken. There is no `dist` folder when installing with `yarn`, and `package.json` also still points to the old executable.

Maybe we should depend on `ts-fly` here instead of adding a compilation step.