### PR TITLE
Update dependencies of @transloadit/analyze-step

### DIFF
--- a/packages/analyze-step/package.json
+++ b/packages/analyze-step/package.json
@@ -26,14 +26,15 @@
   "dependencies": {
     "@transloadit/format-duration-ms": "^0.1.1",
     "@transloadit/prettier-bytes": "^0.1.1",
-    "inflect": "0.4.0",
+    "inflection": "^3.0.0",
     "jsonpath": "1.0.2",
-    "lodash": "4.17.21"
+    "jsonpath-plus": "^7.2.0",
+    "lodash-es": "^4.17.21"
   },
   "version": "0.1.1",
   "gitHead": "b73ab4880b9c4c48db32f249f776974a137510c4",
   "devDependencies": {
     "@types/jsonpath": "^0.2.0",
-    "@types/lodash": "^4.14.182"
+    "@types/lodash-es": "^4.17.10"
   }
 }

--- a/packages/analyze-step/src/analyzeStep.ts
+++ b/packages/analyze-step/src/analyzeStep.ts
@@ -2,16 +2,15 @@
 /* eslint-disable no-template-curly-in-string */
 import formatDurationMs from '@transloadit/format-duration-ms'
 import prettierBytes from '@transloadit/prettier-bytes'
-// @ts-expect-error
-import inflect from 'inflect'
-import _ from 'lodash'
-import jp from 'jsonpath'
+import inflect from 'inflection'
+import { JSONPath } from 'jsonpath-plus'
+import { clone, countBy, get, has } from 'lodash-es'
 
-function humanJoin(array: $TSFixMe, reduce = true, glueword = 'and') {
+function humanJoin(array: string[], reduce = true, glueword = 'and'): string {
   let countedArray = array
 
   if (reduce === true) {
-    const counted = _.countBy(array)
+    const counted = countBy(array)
     countedArray = []
     for (const [name, count] of Object.entries(counted)) {
       if (count > 1) {
@@ -37,7 +36,8 @@ function humanJoin(array: $TSFixMe, reduce = true, glueword = 'and') {
 }
 
 function humanFilter(step: $TSFixMe) {
-  const collection: $TSFixMe = {}
+  const collection: Record<string, string[]> = {}
+
   const templates: Record<string, string> = {
     '<': 'files with {humanKey} below {humanVal}',
     '<=': 'files with {humanKey} of {humanVal} or lower',
@@ -63,7 +63,7 @@ function humanFilter(step: $TSFixMe) {
     } else if (step[type] && step[type].length > 0) {
       // @ts-expect-error
       for (const [key, operator, val] of Object.values(step[type])) {
-        const template = _.clone(templates[operator])
+        const template = clone(templates[operator])
         if (!template) {
           throw new Error(
             `Please add a template definition for this /file/filter operator: ${operator}`
@@ -275,21 +275,21 @@ export default (step: $TSFixMe, robots: $TSFixMe, extrameta = {}) => {
   if (robot.rname === '/video/encode') {
     if (JSON.stringify(step).match(/watermark/)) {
       str = `Watermark videos`
-    } else if (_.get(step, 'ffmpeg.t') && _.get(step, 'ffmpeg.ss')) {
-      str = `Take a ${_.get(step, 'ffmpeg.t')}s clip out of videos at an offset`
-    } else if (_.get(step, 'ffmpeg.t')) {
-      str = `Take a ${_.get(step, 'ffmpeg.t')}s clip out of videos at the beginning`
-    } else if (_.get(step, 'ffmpeg.ss')) {
-      str = `Take a clip out of videos from ${_.get(step, 'ffmpeg.ss')}s till the end`
-    } else if (_.has(step, 'filter:v') && step.ffmpeg['filter:v'] === 'setpts=2.0*PTS') {
+    } else if (get(step, 'ffmpeg.t') && get(step, 'ffmpeg.ss')) {
+      str = `Take a ${get(step, 'ffmpeg.t')}s clip out of videos at an offset`
+    } else if (get(step, 'ffmpeg.t')) {
+      str = `Take a ${get(step, 'ffmpeg.t')}s clip out of videos at the beginning`
+    } else if (get(step, 'ffmpeg.ss')) {
+      str = `Take a clip out of videos from ${get(step, 'ffmpeg.ss')}s till the end`
+    } else if (has(step, 'filter:v') && step.ffmpeg['filter:v'] === 'setpts=2.0*PTS') {
       str = `Slowdown video to half speed`
     } else if (
-      _.has(step, 'ffmpeg.filter_complex') &&
+      has(step, 'ffmpeg.filter_complex') &&
       step.ffmpeg.filter_complex.includes('setpts=')
     ) {
       str = `Change video speed`
     } else if (
-      _.has(step, 'ffmpeg.filter_complex') &&
+      has(step, 'ffmpeg.filter_complex') &&
       step.ffmpeg.filter_complex.includes('atempo=')
     ) {
       str = `Change audio speed`
@@ -314,21 +314,21 @@ export default (step: $TSFixMe, robots: $TSFixMe, extrameta = {}) => {
       str = `Transcode videos to ${humanPreset(step, extrameta)}`
     }
 
-    if (_.get(step, 'ffmpeg.an') === true) {
+    if (get(step, 'ffmpeg.an') === true) {
       str += ' and strip the sound'
     }
   }
 
   if (robot.rname === '/audio/encode') {
-    if (_.has(step, 'ffmpeg.ss') && _.has(step, 'ffmpeg.t')) {
-      str = `Take a ${_.get(step, 'ffmpeg.t')}s clip out of audio at a specified offset`
+    if (has(step, 'ffmpeg.ss') && has(step, 'ffmpeg.t')) {
+      str = `Take a ${get(step, 'ffmpeg.t')}s clip out of audio at a specified offset`
     } else if (
-      _.has(step, 'ffmpeg.filter_complex') &&
+      has(step, 'ffmpeg.filter_complex') &&
       step.ffmpeg.filter_complex.includes('setpts=')
     ) {
       str = `Change video speed`
     } else if (
-      _.has(step, 'ffmpeg.filter_complex') &&
+      has(step, 'ffmpeg.filter_complex') &&
       step.ffmpeg.filter_complex.includes('atempo=')
     ) {
       str = `Change audio speed`
@@ -338,7 +338,7 @@ export default (step: $TSFixMe, robots: $TSFixMe, extrameta = {}) => {
       str = `Encode audio to ${humanPreset(step, extrameta)}`
     }
 
-    if (_.get(step, 'ffmpeg.an') === true) {
+    if (get(step, 'ffmpeg.an') === true) {
       str += ' and strip the sound'
     }
   }
@@ -352,10 +352,10 @@ export default (step: $TSFixMe, robots: $TSFixMe, extrameta = {}) => {
   }
 
   if (robot.rname === '/video/merge') {
-    const types = jp.query(step, '$..as')
+    const types = JSONPath({ path: '$..as', json: step })
     if (types.length) {
       str = `Merge ${humanJoin(types)} to create a new video`
-    } else if (_.get(step, 'ffmpeg.f') === 'gif') {
+    } else if (get(step, 'ffmpeg.f') === 'gif') {
       str = `Create animated GIFs from a series of still images`
     }
   }
@@ -365,7 +365,7 @@ export default (step: $TSFixMe, robots: $TSFixMe, extrameta = {}) => {
   }
 
   if (robot.rname === '/audio/artwork') {
-    if (_.get(step, 'method') === 'insert') {
+    if (get(step, 'method') === 'insert') {
       str = `Insert audio artwork`
     } else {
       str = `Extract audio artwork`

--- a/packages/analyze-step/yarn.lock
+++ b/packages/analyze-step/yarn.lock
@@ -2,15 +2,34 @@
 # yarn lockfile v1
 
 
+"@transloadit/format-duration-ms@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@transloadit/format-duration-ms/-/format-duration-ms-0.1.1.tgz#00e1235e0a5d01f676d8f65b2946742a95fb4080"
+  integrity sha512-OzaJoKLWXKpxIR2yw2O0vR046n95sE9vV8TvZiPTFBt9xHjRgeaE2W7lX5+DKp4SxrkeSeCflNe8p61I1kmkyg==
+  dependencies:
+    pretty-ms "6.0.0"
+
+"@transloadit/prettier-bytes@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@transloadit/prettier-bytes/-/prettier-bytes-0.1.1.tgz#8d5565529fdda67fc437285ccbe6e8c81bca212d"
+  integrity sha512-sgkNv2kzYB65FEzQ32EsQOs/OV3wVR5TgczpYJLs7OKxHKose45RaZaDeJSvvjwUEIkvHUTK9C5LpG6skXPngw==
+
 "@types/jsonpath@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@types/jsonpath/-/jsonpath-0.2.0.tgz#13c62db22a34d9c411364fac79fd374d63445aa1"
   integrity sha512-v7qlPA0VpKUlEdhghbDqRoKMxFB3h3Ch688TApBJ6v+XLDdvWCGLJIYiPKGZnS6MAOie+IorCfNYVHOPIHSWwQ==
 
-"@types/lodash@^4.14.182":
-  version "4.14.182"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.182.tgz#05301a4d5e62963227eaafe0ce04dd77c54ea5c2"
-  integrity sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==
+"@types/lodash-es@^4.17.10":
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.10.tgz#1b36a76ca9eda20c0263e19bbe1a3adb1b317707"
+  integrity sha512-YJP+w/2khSBwbUSFdGsSqmDvmnN3cCKoPOL7Zjle6s30ZtemkkqhjVfFqGwPN7ASil5VyjE2GtyU/yqYY6mC0A==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.200"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.200.tgz#435b6035c7eba9cdf1e039af8212c9e9281e7149"
+  integrity sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q==
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -54,10 +73,15 @@ fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-inflect@0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/inflect/-/inflect-0.4.0.tgz#6a33016a6368d8a70d2513fd230ce8722e980573"
-  integrity sha1-ajMBamNo2KcNJRP9Iwzoci6YBXM=
+inflection@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/inflection/-/inflection-3.0.0.tgz#6a956fa90d72a27d22e6b32ec1064877593ee23b"
+  integrity sha512-1zEJU1l19SgJlmwqsEyFTbScw/tkMHFenUo//Y0i+XEP83gDFdMvPizAD/WGcE+l1ku12PcTVHQhO6g5E0UCMw==
+
+jsonpath-plus@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz#7ad94e147b3ed42f7939c315d2b9ce490c5a3899"
+  integrity sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==
 
 jsonpath@1.0.2:
   version "1.0.2"
@@ -76,10 +100,10 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lodash@4.17.21:
+lodash-es@^4.17.21:
   version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 optionator@^0.8.1:
   version "0.8.3"
@@ -93,10 +117,22 @@ optionator@^0.8.1:
     type-check "~0.3.2"
     word-wrap "~1.2.3"
 
+parse-ms@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-2.1.0.tgz#348565a753d4391fa524029956b172cb7753097d"
+  integrity sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
+
+pretty-ms@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-6.0.0.tgz#39a0eb5f31d359bcee43c9579e6ddf4a02a82ff0"
+  integrity sha512-X5i1y9/8VuBMb9WU8zubTiLKnJG4lcKvL7eaCEVc/jpTe3aS74gCcBM6Yd1vvUDoTCXm4Y15obNS/16yB0FTaQ==
+  dependencies:
+    parse-ms "^2.1.0"
 
 source-map@~0.6.1:
   version "0.6.1"


### PR DESCRIPTION
Updates dependencies to get rid of `underscore`, a dependency of a dependency, which has a critical security vulnerability, as reported on our private website repo. As a bonus, bundle size savings. 