### PR TITLE
Improve types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 module.exports = {
-  extends: ['transloadit', 'prettier'],
+  extends: ['transloadit', 'prettier', 'plugin:@typescript-eslint/recommended'],
   parser: '@typescript-eslint/parser',
   plugins: [
     '@babel/eslint-plugin',
@@ -8,7 +8,6 @@ module.exports = {
     'node',
     'prefer-import',
     'promise',
-    // extra:
     '@typescript-eslint',
   ],
   settings: {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@babel/eslint-parser": "^7.18.9",
     "@babel/eslint-plugin": "^7.18.10",
     "@sucrase/jest-plugin": "^2.2.1",
+    "@types/inflection": "^1.13.1",
     "@types/jest": "^29.0.0",
     "@types/node": "^18.7.14",
     "@typescript-eslint/eslint-plugin": "^5.36.1",

--- a/packages/abbr/package.json
+++ b/packages/abbr/package.json
@@ -19,7 +19,7 @@
     "test": "dist"
   },
   "scripts": {
-    "tsc": "tsc",
+    "tsc": "tsc --build --clean && tsc --build",
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "version": "0.1.2"

--- a/packages/abbr/src/abbr.ts
+++ b/packages/abbr/src/abbr.ts
@@ -1,4 +1,4 @@
-export default function abbr(str: $TSFixMe, maxLength = 55, divider = `[...]`) {
+export default function abbr(str: string, maxLength = 55, divider = `[...]`): string {
   if (str !== `${str}`) {
     return str
   }

--- a/packages/abbr/src/global.d.ts
+++ b/packages/abbr/src/global.d.ts
@@ -1,3 +1,0 @@
-/* eslint-disable no-unused-vars */
-type $TSFixMe = any
-type $TSFixMeFunction = (...args: $TSFixMe[]) => any

--- a/packages/analyze-step/package.json
+++ b/packages/analyze-step/package.json
@@ -19,7 +19,7 @@
     "test": "dist"
   },
   "scripts": {
-    "tsc": "tsc",
+    "tsc": "tsc --build --clean && tsc --build",
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {

--- a/packages/analyze-step/src/analyzeStep.ts
+++ b/packages/analyze-step/src/analyzeStep.ts
@@ -153,11 +153,10 @@ function humanFilter(step: FileFilterStep): string {
 
   const total = []
   if (collection.declines && collection.declines.length > 0) {
-    const joindec = humanJoin(
-      (collection as $TSFixMe).declines,
-      false,
-      step.condition_type
-    ).replace('with a certain mime-type and with a certain mime-type', 'with certain mime-types')
+    const joindec = humanJoin(collection.declines, false, step.condition_type).replace(
+      'with a certain mime-type and with a certain mime-type',
+      'with certain mime-types'
+    )
 
     total.push(`Exclude ${joindec}`)
   }
@@ -241,8 +240,8 @@ function humanPreset(step: PresetStep, extrameta: ExtraMeta = {}): string {
     quality = quality ? ` (${quality} quality)` : ``
 
     let device = `iPad${quality}`
-    if ((extrameta as $TSFixMe).deviceName) {
-      device = `${(extrameta as $TSFixMe).deviceName}`
+    if (extrameta.deviceName) {
+      device = `${extrameta.deviceName}`
     }
 
     str = `${device} (H.264)`

--- a/packages/analyze-step/src/global.d.ts
+++ b/packages/analyze-step/src/global.d.ts
@@ -1,3 +1,0 @@
-/* eslint-disable no-unused-vars */
-type $TSFixMe = any
-type $TSFixMeFunction = (...args: $TSFixMe[]) => any

--- a/packages/enrich-tweet/package.json
+++ b/packages/enrich-tweet/package.json
@@ -20,7 +20,7 @@
     "test": "dist"
   },
   "scripts": {
-    "tsc": "tsc",
+    "tsc": "tsc --build --clean && tsc --build",
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {

--- a/packages/enrich-tweet/src/enrichTweet.ts
+++ b/packages/enrich-tweet/src/enrichTweet.ts
@@ -39,6 +39,7 @@ export default async function enrichTweet(
   if (!tweet) return
 
   let text = tweet.full_text
+
   // Expand URLs
   if (tweet.entities && tweet.entities.urls.length) {
     const subUrls = tweet.entities.urls
@@ -93,5 +94,6 @@ export default async function enrichTweet(
     '<a class="tweet-url username" href="https://twitter.com/$1" data-screen-name="$2" rel="nofollow">@$3</a>'
   )
 
+  // eslint-disable-next-line consistent-return
   return text
 }

--- a/packages/enrich-tweet/src/enrichTweet.ts
+++ b/packages/enrich-tweet/src/enrichTweet.ts
@@ -3,25 +3,47 @@ import { tall } from 'tall'
 
 import getUrls from 'get-urls'
 
-export default async function enrichTweet(tweet: $TSFixMe, unshorten = true) {
-  async function tryUnshorten(url: $TSFixMe) {
-    if (!unshorten) return url
-    try {
-      return await tall(url)
-    } catch (err) {
-      return url
-    }
+async function tryUnshorten(url: string, unshorten: boolean): Promise<string> {
+  if (!unshorten) return url
+  try {
+    return await tall(url)
+  } catch (err) {
+    return url
   }
+}
 
-  if (!tweet) {
-    return tweet
+type Tweet = {
+  full_text: string
+  entities?: {
+    urls: {
+      display_url: string
+      url: string
+      expanded_url: string
+    }[]
   }
+  extended_entities?: {
+    media: {
+      display_url: string
+      url: string
+      media_url: string
+      media_url_https: string
+      expanded_url: string
+    }[]
+  }
+}
+
+export default async function enrichTweet(
+  tweet: Tweet,
+  unshorten = true
+): Promise<string | undefined> {
+  if (!tweet) return
+
   let text = tweet.full_text
   // Expand URLs
   if (tweet.entities && tweet.entities.urls.length) {
     const subUrls = tweet.entities.urls
     for (const subUrl1 of subUrls) {
-      const unshortened = await tryUnshorten(subUrl1.expanded_url)
+      const unshortened = await tryUnshorten(subUrl1.expanded_url, unshorten)
       const friends1 = [subUrl1.display_url, subUrl1.url, subUrl1.expanded_url]
       for (const friend1 of friends1) {
         text = text.replace(`http://www.${friend1}`, unshortened)
@@ -49,7 +71,7 @@ export default async function enrichTweet(tweet: $TSFixMe, unshorten = true) {
     if (!subUrl3.match(/^https?:\/\/bit\.ly/)) {
       continue
     }
-    const unshortened3 = await tryUnshorten(subUrl3)
+    const unshortened3 = await tryUnshorten(subUrl3, unshorten)
     text = text.replace(`${subUrl3}`, `${unshortened3}`)
   }
 

--- a/packages/enrich-tweet/src/global.d.ts
+++ b/packages/enrich-tweet/src/global.d.ts
@@ -1,3 +1,0 @@
-/* eslint-disable no-unused-vars */
-type $TSFixMe = any
-type $TSFixMeFunction = (...args: $TSFixMe[]) => any

--- a/packages/file-exists/package.json
+++ b/packages/file-exists/package.json
@@ -20,7 +20,7 @@
     "test": "dist"
   },
   "scripts": {
-    "tsc": "tsc",
+    "tsc": "tsc --build --clean && tsc --build",
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "gitHead": "b73ab4880b9c4c48db32f249f776974a137510c4"

--- a/packages/file-exists/src/fileExists.ts
+++ b/packages/file-exists/src/fileExists.ts
@@ -1,10 +1,8 @@
 import fs from 'fs'
 
-export default function fileExists(s: $TSFixMe) {
-  // eslint-disable-next-line no-unused-vars
-  return new Promise((resolve, reject) => {
-    // @ts-expect-error
-    fs.access(s, fs.F_OK, (err: $TSFixMe) => {
+export default function fileExists(path: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    fs.access(path, fs.constants.F_OK, (err) => {
       resolve(!err)
     })
   })

--- a/packages/file-exists/src/global.d.ts
+++ b/packages/file-exists/src/global.d.ts
@@ -1,3 +1,0 @@
-/* eslint-disable no-unused-vars */
-type $TSFixMe = any
-type $TSFixMeFunction = (...args: $TSFixMe[]) => any

--- a/packages/format-duration-ms/package.json
+++ b/packages/format-duration-ms/package.json
@@ -19,7 +19,7 @@
     "test": "dist"
   },
   "scripts": {
-    "tsc": "tsc",
+    "tsc": "tsc --build --clean && tsc --build",
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {

--- a/packages/format-duration-ms/src/formatDurationMs.ts
+++ b/packages/format-duration-ms/src/formatDurationMs.ts
@@ -1,6 +1,6 @@
 import prettyMS from 'pretty-ms'
 
-export default function formatDurationMs(ms: $TSFixMe) {
+export default function formatDurationMs(ms: number): string {
   let human = prettyMS(ms)
 
   human = human.replace(/(\d+)\.\d+s/g, '$1s')

--- a/packages/format-duration-ms/src/global.d.ts
+++ b/packages/format-duration-ms/src/global.d.ts
@@ -1,3 +1,0 @@
-/* eslint-disable no-unused-vars */
-type $TSFixMe = any
-type $TSFixMeFunction = (...args: $TSFixMe[]) => any

--- a/packages/has-property/LICENSE.md
+++ b/packages/has-property/LICENSE.md
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+Everyone is permitted to copy and distribute verbatim copies
+of this license document, but changing it is not allowed.
+
+                            Preamble
+
+The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works. By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+When we speak of free software, we are referring to freedom, not
+price. Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate. Many developers of free software are heartened and
+encouraged by the resulting cooperation. However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community. It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server. Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals. This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+0. Definitions.
+
+"This License" refers to version 3 of the GNU Affero General Public License.
+
+"Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+"The Program" refers to any copyrightable work licensed under this
+License. Each licensee is addressed as "you". "Licensees" and
+"recipients" may be individuals or organizations.
+
+To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy. The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy. Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies. Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License. If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+1. Source Code.
+
+The "source code" for a work means the preferred form of the work
+for making modifications to it. "Object code" means any non-source
+form of a work.
+
+A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form. A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities. However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work. For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+The Corresponding Source for a work in source code form is that
+same work.
+
+2. Basic Permissions.
+
+All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met. This License explicitly affirms your unlimited
+permission to run the unmodified Program. The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work. This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force. You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright. Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+Conveying under any other circumstances is permitted solely under
+the conditions stated below. Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+4. Conveying Verbatim Copies.
+
+You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+5. Conveying Modified Source Versions.
+
+You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit. Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+6. Conveying Non-Source Forms.
+
+You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling. In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage. For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product. A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+"Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source. The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information. But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed. Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+7. Additional Terms.
+
+"Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law. If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it. (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.) You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10. If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term. If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+8. Termination.
+
+You may not propagate or modify a covered work except as expressly
+provided under this License. Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License. If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+9. Acceptance Not Required for Having Copies.
+
+You are not required to accept this License in order to receive or
+run a copy of the Program. Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance. However,
+nothing other than this License grants you permission to propagate or
+modify any covered work. These actions infringe copyright if you do
+not accept this License. Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+10. Automatic Licensing of Downstream Recipients.
+
+Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License. You are not responsible
+for enforcing compliance by third parties with this License.
+
+An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations. If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License. For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+11. Patents.
+
+A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based. The
+work thus licensed is called the contributor's "contributor version".
+
+A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version. For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement). To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients. "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License. You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+12. No Surrender of Others' Freedom.
+
+If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License. If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all. For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+13. Remote Network Interaction; Use with the GNU General Public License.
+
+Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software. This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work. The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+14. Revised Versions of this License.
+
+The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time. Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number. If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation. If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+Later license versions may give you additional or different
+permissions. However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+15. Disclaimer of Warranty.
+
+THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+16. Limitation of Liability.
+
+IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+17. Interpretation of Sections 15 and 16.
+
+If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program. It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source. For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code. There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/packages/has-property/README.md
+++ b/packages/has-property/README.md
@@ -1,0 +1,3 @@
+> Even though this module is publicly accessible, we do not recommend using it in projects outside of [Transloadit](https://transloadit.com). We won't make any guarantees about its workings and can change things at any time, we won't adhere strictly to SemVer.
+
+> This module is maintained from a monorepo called [monolib](https://github.com/transloadit/monolib).

--- a/packages/has-property/package.json
+++ b/packages/has-property/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "@transloadit/sort-result-meta",
+  "name": "@transloadit/has-property",
   "license": "AGPL-3.0-only",
-  "version": "0.1.2",
+  "version": "0.0.0",
   "publishConfig": {
     "access": "public"
   },
   "repository": {
     "type": "git",
     "url": "git://github.com/transloadit/monolib.git",
-    "directory": "packages/sort-result-meta"
+    "directory": "packages/has-property"
   },
-  "main": "dist/sortResultMeta.js",
-  "typings": "dist/sortResultMeta.d.ts",
+  "main": "dist/has-property.js",
+  "typings": "dist/has-property.d.ts",
   "files": [
     "dist"
   ],
@@ -22,9 +22,5 @@
   "scripts": {
     "tsc": "tsc --build --clean && tsc --build",
     "test": "echo \"Error: run tests from root\" && exit 1"
-  },
-  "dependencies": {
-    "@transloadit/has-property": "^0.0.0",
-    "@transloadit/sort-object-by-prio": "^0.1.2"
   }
 }

--- a/packages/has-property/src/has-property.test.ts
+++ b/packages/has-property/src/has-property.test.ts
@@ -1,0 +1,8 @@
+import { hasProperty } from './has-property'
+
+test('hasProperty', () => {
+  expect(hasProperty({ foo: 'bar' }, 'foo')).toBe(true)
+  expect(hasProperty({ foo: 'bar' }, 'bar')).toBe(false)
+  expect(hasProperty({ foo: 'bar' }, 'constructor')).toBe(false)
+  expect(hasProperty('foo', 'foo')).toBe(false)
+})

--- a/packages/has-property/src/has-property.ts
+++ b/packages/has-property/src/has-property.ts
@@ -1,0 +1,7 @@
+// eslint-disable-next-line import/prefer-default-export
+export function hasProperty<K extends PropertyKey>(
+  obj: unknown,
+  key: K | null | undefined
+): obj is Record<K, unknown> {
+  return key != null && obj != null && typeof obj === 'object' && key in obj
+}

--- a/packages/has-property/src/has-property.ts
+++ b/packages/has-property/src/has-property.ts
@@ -3,5 +3,5 @@ export function hasProperty<K extends PropertyKey>(
   obj: unknown,
   key: K | null | undefined
 ): obj is Record<K, unknown> {
-  return key != null && obj != null && typeof obj === 'object' && key in obj
+  return key != null && obj != null && typeof obj === 'object' && Object.hasOwn(obj, key)
 }

--- a/packages/has-property/tsconfig.json
+++ b/packages/has-property/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist",
-    "resolveJsonModule": true
+    "outDir": "./dist"
   },
   "include": ["./src"]
 }

--- a/packages/post/package.json
+++ b/packages/post/package.json
@@ -19,7 +19,7 @@
     "test": "dist"
   },
   "scripts": {
-    "tsc": "tsc",
+    "tsc": "tsc --build --clean && tsc --build",
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {

--- a/packages/post/src/global.d.ts
+++ b/packages/post/src/global.d.ts
@@ -1,3 +1,0 @@
-/* eslint-disable no-unused-vars */
-type $TSFixMe = any
-type $TSFixMeFunction = (...args: $TSFixMe[]) => any

--- a/packages/post/src/open-in-editor.d.ts
+++ b/packages/post/src/open-in-editor.d.ts
@@ -1,0 +1,55 @@
+/* eslint-disable max-classes-per-file */
+
+declare module 'open-in-editor' {
+  class OpenInEditor {
+    open(path: string): Promise<void>
+  }
+
+  interface CreateOpenInEditorOptions {
+    /**
+     * Editor to open a file. Once value is set, we try to detect a command to launch an editor.
+     *
+     * @default null
+     */
+    editor?:
+      | 'sublime'
+      | 'atom'
+      | 'code'
+      | 'webstorm'
+      | 'phpstorm'
+      | 'idea14ce'
+      | 'vim'
+      | 'emacs'
+      | 'visualstudio'
+      | null
+    /**
+     * Command to launch an editor.
+     *
+     * @default null
+     */
+    cmd?: string | null
+    /**
+     * Option to specify arguments for a command. Pattern can contain placeholders to be replaced by actual values. Supported placeholders: filename, line and column.
+     *
+     * @default null
+     */
+    pattern?: string | null
+    /**
+     * Number of the first line in the editor
+     * @default 1
+     */
+    line?: number
+    /**
+     * Number of the first column in the editor
+     * @default 1
+     */
+    column?: number
+  }
+
+  function configure(
+    opts?: CreateOpenInEditorOptions,
+    failCallback?: (err: Error) => void
+  ): OpenInEditor
+
+  export = { configure }
+}

--- a/packages/post/src/post.ts
+++ b/packages/post/src/post.ts
@@ -8,7 +8,7 @@ import fileExists from '@transloadit/file-exists'
 import slugify from '@transloadit/slugify'
 import title from 'title'
 
-async function post() {
+async function post(): Promise<void> {
   // eslint-disable-next-line import/no-dynamic-require,global-require
   console.log(`Welcome to @transloadit/post@${require(`${__dirname}/package.json`).version}. `)
   console.log(`Please answer some questions about the blog post, `)

--- a/packages/post/src/post.ts
+++ b/packages/post/src/post.ts
@@ -2,15 +2,15 @@
 /* eslint-disable no-console */
 import { promises as fs } from 'fs'
 import inquirer from 'inquirer'
-// @ts-expect-error
+
 import openInEditor from 'open-in-editor'
 import fileExists from '@transloadit/file-exists'
 import slugify from '@transloadit/slugify'
 import title from 'title'
+import packageJson from '../package.json'
 
 async function post(): Promise<void> {
-  // eslint-disable-next-line import/no-dynamic-require,global-require
-  console.log(`Welcome to @transloadit/post@${require(`${__dirname}/package.json`).version}. `)
+  console.log(`Welcome to @transloadit/post@${packageJson.version}. `)
   console.log(`Please answer some questions about the blog post, `)
   console.log(`and I'll generate a starting point and open your editor. `)
 
@@ -21,7 +21,7 @@ async function post(): Promise<void> {
 
   const mysqlNow = new Date().toISOString().replace('T', ' ').split('.')[0].split(' ')[0]
   // eslint-disable-next-line no-unused-vars
-  const [dateY, datem, dated] = mysqlNow.split('-')
+  const [dateY, datem] = mysqlNow.split('-')
   const answers = await inquirer.prompt([
     { type: 'input', name: 'title', message: 'title:' },
     { type: 'input', name: 'author', message: 'author:', default: process.env.USER },
@@ -70,11 +70,10 @@ async function post(): Promise<void> {
   }
 
   const editor = openInEditor.configure(opts)
-  await editor.open(`${outFile}`, {
-    line: 10,
-  })
+  await editor.open(`${outFile}`)
   console.log(`Done. `)
 }
+
 post().catch((err) => {
   console.error(err)
   process.exit(1)

--- a/packages/pr/package.json
+++ b/packages/pr/package.json
@@ -20,7 +20,7 @@
     "test": "dist"
   },
   "scripts": {
-    "tsc": "tsc",
+    "tsc": "tsc --build --clean && tsc --build",
     "test": "echo \"Error: run tests from root\" && exit 1"
   }
 }

--- a/packages/pr/src/global.d.ts
+++ b/packages/pr/src/global.d.ts
@@ -1,3 +1,0 @@
-/* eslint-disable no-unused-vars */
-type $TSFixMe = any
-type $TSFixMeFunction = (...args: $TSFixMe[]) => any

--- a/packages/pr/src/pr.ts
+++ b/packages/pr/src/pr.ts
@@ -1,6 +1,6 @@
 import * as util from 'util'
 
-export default function pr(...args: $TSFixMe[]) {
+export default function pr<T>(...args: T[]): T[] {
   for (const arg of args) {
     console.log(util.inspect(arg, false, null, true))
   }

--- a/packages/prd/package.json
+++ b/packages/prd/package.json
@@ -20,7 +20,7 @@
     "test": "dist"
   },
   "scripts": {
-    "tsc": "tsc",
+    "tsc": "tsc --build --clean && tsc --build",
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {

--- a/packages/prd/src/global.d.ts
+++ b/packages/prd/src/global.d.ts
@@ -1,3 +1,0 @@
-/* eslint-disable no-unused-vars */
-type $TSFixMe = any
-type $TSFixMeFunction = (...args: $TSFixMe[]) => any

--- a/packages/prd/src/prd.test.ts
+++ b/packages/prd/src/prd.test.ts
@@ -2,9 +2,12 @@ import prd from './prd'
 
 describe('prd', () => {
   test('main', async () => {
-    // @ts-expect-error
-    const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {})
-    jest.spyOn(console, 'error').mockImplementation((e: $TSFixMe) => {
+    const mockExit = jest
+      .spyOn(process, 'exit')
+      // @ts-expect-error - process.exit should return never but that is impossible here
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      .mockImplementation((code?: number) => {})
+    jest.spyOn(console, 'error').mockImplementation((e: Error) => {
       expect(e.message).toStrictEqual('Halt via prd')
     })
     prd('foo')

--- a/packages/prd/src/prd.ts
+++ b/packages/prd/src/prd.ts
@@ -1,6 +1,6 @@
 import pr from '@transloadit/pr'
 
-export default function prd(...args: $TSFixMe[]) {
+export default function prd<T>(...args: T[]): void {
   pr(...args)
   const err = new Error('Halt via prd')
   console.error(err)

--- a/packages/prettier-bytes/package.json
+++ b/packages/prettier-bytes/package.json
@@ -20,7 +20,7 @@
     "test": "dist"
   },
   "scripts": {
-    "tsc": "tsc",
+    "tsc": "tsc --build --clean && tsc --build",
     "test": "echo \"Error: run tests from root\" && exit 1"
   }
 }

--- a/packages/prettier-bytes/src/global.d.ts
+++ b/packages/prettier-bytes/src/global.d.ts
@@ -1,3 +1,0 @@
-/* eslint-disable no-unused-vars */
-type $TSFixMe = any
-type $TSFixMeFunction = (...args: $TSFixMe[]) => any

--- a/packages/prettier-bytes/src/prettierBytes.ts
+++ b/packages/prettier-bytes/src/prettierBytes.ts
@@ -1,8 +1,8 @@
 // Adapted from https://github.com/Flet/prettier-bytes/
 // Changing 1000 bytes to 1024, so we can keep uppercase KB vs kB
 // ISC License (c) Dan Flettre https://github.com/Flet/prettier-bytes/blob/master/LICENSE
-export default function prettierBytes(num: $TSFixMe) {
-  if (typeof num !== 'number' || isNaN(num)) {
+export default function prettierBytes(num: number): string {
+  if (typeof num !== 'number' || Number.isNaN(num)) {
     throw new TypeError(`Expected a number, got ${typeof num}`)
   }
 

--- a/packages/slugify/package.json
+++ b/packages/slugify/package.json
@@ -20,7 +20,7 @@
     "test": "dist"
   },
   "scripts": {
-    "tsc": "tsc",
+    "tsc": "tsc --build --clean && tsc --build",
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "gitHead": "b73ab4880b9c4c48db32f249f776974a137510c4"

--- a/packages/slugify/src/global.d.ts
+++ b/packages/slugify/src/global.d.ts
@@ -1,3 +1,0 @@
-/* eslint-disable no-unused-vars */
-type $TSFixMe = any
-type $TSFixMeFunction = (...args: $TSFixMe[]) => any

--- a/packages/slugify/src/slugify.ts
+++ b/packages/slugify/src/slugify.ts
@@ -1,7 +1,6 @@
-export default function slugify(str: $TSFixMe) {
-  if (!str || str !== `${str}`) {
-    return str
-  }
+export default function slugify(str: string): string {
+  if (!str || str !== `${str}`) return str
+
   return str
     .toLowerCase()
     .replace(/[^a-z0-9]+/gi, '-')

--- a/packages/sort-assembly/package.json
+++ b/packages/sort-assembly/package.json
@@ -20,7 +20,7 @@
     "test": "dist"
   },
   "scripts": {
-    "tsc": "tsc",
+    "tsc": "tsc --build --clean && tsc --build",
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {

--- a/packages/sort-assembly/package.json
+++ b/packages/sort-assembly/package.json
@@ -24,6 +24,7 @@
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {
+    "@transloadit/has-property": "^0.0.0",
     "@transloadit/sort-object-by-prio": "^0.1.2",
     "@transloadit/sort-result": "^0.1.2"
   }

--- a/packages/sort-assembly/src/global.d.ts
+++ b/packages/sort-assembly/src/global.d.ts
@@ -1,3 +1,0 @@
-/* eslint-disable no-unused-vars */
-type $TSFixMe = any
-type $TSFixMeFunction = (...args: $TSFixMe[]) => any

--- a/packages/sort-assembly/src/sortAssembly.ts
+++ b/packages/sort-assembly/src/sortAssembly.ts
@@ -1,7 +1,7 @@
 import sortObjectByPrio from '@transloadit/sort-object-by-prio'
 import sortResult from '@transloadit/sort-result'
 
-export default function sortAssembly(assembly: $TSFixMe) {
+export default function sortAssembly<T extends Record<string, unknown>>(assembly: T): T {
   const sorted = sortObjectByPrio(assembly, {
     _: ['assembly_id', 'ok', 'message', 'warnings', 'error'],
     z: ['uploads', 'results'],

--- a/packages/sort-assembly/src/sortAssembly.ts
+++ b/packages/sort-assembly/src/sortAssembly.ts
@@ -1,5 +1,6 @@
 import sortObjectByPrio from '@transloadit/sort-object-by-prio'
 import sortResult from '@transloadit/sort-result'
+import { hasProperty } from '@transloadit/has-property'
 
 export default function sortAssembly<T extends Record<string, unknown>>(assembly: T): T {
   const sorted = sortObjectByPrio(assembly, {
@@ -7,16 +8,20 @@ export default function sortAssembly<T extends Record<string, unknown>>(assembly
     z: ['uploads', 'results'],
   })
 
-  if ('results' in sorted) {
-    for (const stepName in sorted.results) {
-      for (const i in sorted.results[stepName]) {
-        sorted.results[stepName][i] = sortResult(sorted.results[stepName][i])
+  if ('results' in sorted && typeof sorted.results === 'object') {
+    for (const stepName of Object.keys(sorted.results)) {
+      if (!hasProperty(sorted.results, stepName)) continue
+      const result = sorted.results[stepName]
+      for (const i of Object.keys(result)) {
+        if (!hasProperty(result, i)) continue
+        result[i] = sortResult(result[i])
       }
     }
   }
 
   if ('uploads' in sorted) {
-    for (const i in sorted.uploads) {
+    for (const i of Object.keys(sorted.uploads)) {
+      if (!hasProperty(sorted.uploads, i)) continue
       sorted.uploads[i] = sortResult(sorted.uploads[i])
     }
   }

--- a/packages/sort-object-by-prio/package.json
+++ b/packages/sort-object-by-prio/package.json
@@ -20,7 +20,7 @@
     "test": "dist"
   },
   "scripts": {
-    "tsc": "tsc",
+    "tsc": "tsc --build --clean && tsc --build",
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {

--- a/packages/sort-object-by-prio/src/global.d.ts
+++ b/packages/sort-object-by-prio/src/global.d.ts
@@ -1,3 +1,0 @@
-/* eslint-disable no-unused-vars */
-type $TSFixMe = any
-type $TSFixMeFunction = (...args: $TSFixMe[]) => any

--- a/packages/sort-object-by-prio/src/sortObjectByPrio.ts
+++ b/packages/sort-object-by-prio/src/sortObjectByPrio.ts
@@ -4,7 +4,10 @@ type Prefixes = {
   [prefix: string]: Array<string | RegExp>
 }
 
-export default function sortObjectByPrio(obj: $TSFixMe, prefixes: Prefixes) {
+export default function sortObjectByPrio<T extends Record<string, unknown>>(
+  obj: T,
+  prefixes: Prefixes
+): T {
   return sortObject(obj, (argA: string, argB: string) => {
     let a = argA
     let b = argB

--- a/packages/sort-object/package.json
+++ b/packages/sort-object/package.json
@@ -22,5 +22,8 @@
   "scripts": {
     "tsc": "tsc --build --clean && tsc --build",
     "test": "echo \"Error: run tests from root\" && exit 1"
+  },
+  "dependencies": {
+    "@transloadit/has-property": "^0.0.0"
   }
 }

--- a/packages/sort-object/package.json
+++ b/packages/sort-object/package.json
@@ -20,7 +20,7 @@
     "test": "dist"
   },
   "scripts": {
-    "tsc": "tsc",
+    "tsc": "tsc --build --clean && tsc --build",
     "test": "echo \"Error: run tests from root\" && exit 1"
   }
 }

--- a/packages/sort-object/src/global.d.ts
+++ b/packages/sort-object/src/global.d.ts
@@ -1,3 +1,0 @@
-/* eslint-disable no-unused-vars */
-type $TSFixMe = any
-type $TSFixMeFunction = (...args: $TSFixMe[]) => any

--- a/packages/sort-object/src/sortObject.ts
+++ b/packages/sort-object/src/sortObject.ts
@@ -1,9 +1,12 @@
-export default function sortObject(obj: $TSFixMe, sortFunc?: $TSFixMe) {
+export default function sortObject<T extends Record<string, unknown>>(
+  obj: T,
+  sortFunc?: (a: string, b: string) => number
+): T {
   // yeah i know, sorting objects in js doesn't work :)
   return Object.keys(obj)
     .sort(sortFunc)
-    .reduce((result: $TSFixMe, key) => {
+    .reduce((result, key: keyof T) => {
       result[key] = obj[key]
       return result
-    }, {})
+    }, {} as T)
 }

--- a/packages/sort-object/src/sortObject.ts
+++ b/packages/sort-object/src/sortObject.ts
@@ -1,5 +1,6 @@
 export default function sortObject<T extends Record<string, unknown>>(
   obj: T,
+  // eslint-disable-next-line no-unused-vars
   sortFunc?: (a: string, b: string) => number
 ): T {
   // yeah i know, sorting objects in js doesn't work :)

--- a/packages/sort-result-meta/package.json
+++ b/packages/sort-result-meta/package.json
@@ -20,7 +20,7 @@
     "test": "dist"
   },
   "scripts": {
-    "tsc": "tsc",
+    "tsc": "tsc --build --clean && tsc --build",
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {

--- a/packages/sort-result-meta/src/global.d.ts
+++ b/packages/sort-result-meta/src/global.d.ts
@@ -1,3 +1,0 @@
-/* eslint-disable no-unused-vars */
-type $TSFixMe = any
-type $TSFixMeFunction = (...args: $TSFixMe[]) => any

--- a/packages/sort-result-meta/src/sortResultMeta.ts
+++ b/packages/sort-result-meta/src/sortResultMeta.ts
@@ -1,13 +1,25 @@
 import sortObjectByPrio from '@transloadit/sort-object-by-prio'
+import { hasProperty } from '@transloadit/has-property'
 
 type Meta = {
   faces?: Record<string, unknown>
 }
 
+function isObject(obj: unknown): obj is Record<string, unknown> {
+  return (
+    typeof obj === 'object' && obj !== null && Object.keys(obj).every((x) => typeof x === 'string')
+  )
+}
+
 export default function sortResultMeta<T extends Meta>(meta: T): T {
-  if ('faces' in meta) {
-    for (const i in meta.faces) {
-      meta.faces[i] = sortObjectByPrio(meta.faces[i], {
+  if (hasProperty(meta, 'faces')) {
+    for (const key of Object.keys(meta.faces)) {
+      if (!hasProperty(meta.faces, key)) continue
+
+      const obj = meta.faces[key]
+      if (!isObject(obj)) continue
+
+      meta.faces[key] = sortObjectByPrio(obj, {
         _: [],
         z: ['x1', 'y1', 'x2', 'y2'],
       })

--- a/packages/sort-result-meta/src/sortResultMeta.ts
+++ b/packages/sort-result-meta/src/sortResultMeta.ts
@@ -1,6 +1,10 @@
 import sortObjectByPrio from '@transloadit/sort-object-by-prio'
 
-export default function sortResultMeta(meta: $TSFixMe) {
+type Meta = {
+  faces?: Record<string, unknown>
+}
+
+export default function sortResultMeta<T extends Meta>(meta: T): T {
   if ('faces' in meta) {
     for (const i in meta.faces) {
       meta.faces[i] = sortObjectByPrio(meta.faces[i], {

--- a/packages/sort-result/package.json
+++ b/packages/sort-result/package.json
@@ -24,6 +24,7 @@
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {
+    "@transloadit/has-property": "^0.0.0",
     "@transloadit/sort-object-by-prio": "^0.1.2",
     "@transloadit/sort-result-meta": "^0.1.2"
   }

--- a/packages/sort-result/package.json
+++ b/packages/sort-result/package.json
@@ -20,7 +20,7 @@
     "test": "dist"
   },
   "scripts": {
-    "tsc": "tsc",
+    "tsc": "tsc --build --clean && tsc --build",
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {

--- a/packages/sort-result/src/global.d.ts
+++ b/packages/sort-result/src/global.d.ts
@@ -1,3 +1,0 @@
-/* eslint-disable no-unused-vars */
-type $TSFixMe = any
-type $TSFixMeFunction = (...args: $TSFixMe[]) => any

--- a/packages/sort-result/src/sortResult.ts
+++ b/packages/sort-result/src/sortResult.ts
@@ -1,13 +1,14 @@
+import { hasProperty } from '@transloadit/has-property'
 import sortObjectByPrio from '@transloadit/sort-object-by-prio'
 import sortResultMeta from '@transloadit/sort-result-meta'
 
-export default function sortResult<T extends Record<string, unknown>>(result: T): T {
+export default function sortResult<T extends { meta?: unknown }>(result: T): T {
   const sorted = sortObjectByPrio(result, {
     _: ['id'],
     z: ['meta'],
   })
 
-  if ('meta' in sorted) {
+  if (hasProperty(sorted, 'meta')) {
     sorted.meta = sortResultMeta(sorted.meta)
   }
 

--- a/packages/sort-result/src/sortResult.ts
+++ b/packages/sort-result/src/sortResult.ts
@@ -1,7 +1,7 @@
 import sortObjectByPrio from '@transloadit/sort-object-by-prio'
 import sortResultMeta from '@transloadit/sort-result-meta'
 
-export default function sortResult(result: $TSFixMe) {
+export default function sortResult<T extends Record<string, unknown>>(result: T): T {
   const sorted = sortObjectByPrio(result, {
     _: ['id'],
     z: ['meta'],

--- a/packages/trigger-pager/package.json
+++ b/packages/trigger-pager/package.json
@@ -20,7 +20,7 @@
     "test": "dist"
   },
   "scripts": {
-    "tsc": "tsc",
+    "tsc": "tsc --build --clean && tsc --build",
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {

--- a/packages/trigger-pager/src/global.d.ts
+++ b/packages/trigger-pager/src/global.d.ts
@@ -1,3 +1,0 @@
-/* eslint-disable no-unused-vars */
-type $TSFixMe = any
-type $TSFixMeFunction = (...args: $TSFixMe[]) => any

--- a/packages/trigger-pager/src/triggerPager.test.ts
+++ b/packages/trigger-pager/src/triggerPager.test.ts
@@ -16,13 +16,15 @@ jest.mock('@pagerduty/pdjs')
 
 describe('triggerPager', () => {
   test('main', async () => {
-    const post = jest.fn(async (endpoint: $TSFixMe, payload: $TSFixMe) => {
+    const post = jest.fn(async (endpoint: string, payload: unknown) => {
       expect(endpoint).toBe('/incidents')
       expect(payload).toMatchSnapshot()
       return { data: { error: null } }
     })
-    // @ts-expect-error
+
+    // @ts-expect-error - api is mocked by jest so mockReturnValue exists
     api.mockReturnValue({ post })
+
     await triggerPager({
       title: LOREM3,
       description: LOREM3,
@@ -42,7 +44,8 @@ describe('triggerPager', () => {
         },
       }
     })
-    // @ts-expect-error
+
+    // @ts-expect-error - api is mocked by jest so mockReturnValue exists
     api.mockReturnValue({ post })
 
     let err
@@ -55,7 +58,7 @@ describe('triggerPager', () => {
       err = _err
     }
 
-    expect((err as $TSFixMe).message).toBe('oh no - oh; no')
+    expect(err.message).toBe('oh no - oh; no')
   })
 
   test('duplicate incident', async () => {
@@ -69,7 +72,8 @@ describe('triggerPager', () => {
         },
       }
     })
-    // @ts-expect-error
+
+    // @ts-expect-error - api is mocked by jest so mockReturnValue exists
     api.mockReturnValue({ post })
 
     await triggerPager({

--- a/packages/trigger-pager/src/triggerPager.ts
+++ b/packages/trigger-pager/src/triggerPager.ts
@@ -3,6 +3,16 @@ const { api } = require('@pagerduty/pdjs')
 const PRIORITY_P1 = 'PUTY3A1'
 const DUPLICATE_INCIDENT_MESSAGE = 'matching dedup key already exists'
 
+export type TriggerPagerOptions = {
+  description: string
+  from?: string
+  incidentKey: string
+  serviceId: string
+  title: string
+  token: string
+  urgency?: 'low' | 'high'
+}
+
 const triggerPager = async ({
   token,
   serviceId,
@@ -11,7 +21,7 @@ const triggerPager = async ({
   from = 'tim.koschuetzki@transloadit.com',
   title = incidentKey,
   description,
-}: $TSFixMe) => {
+}: TriggerPagerOptions): Promise<void> => {
   const res = await api({ token }).post('/incidents', {
     headers: {
       from,

--- a/packages/trigger-pager/src/triggerPager.ts
+++ b/packages/trigger-pager/src/triggerPager.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { api } = require('@pagerduty/pdjs')
 
 const PRIORITY_P1 = 'PUTY3A1'
@@ -6,10 +7,10 @@ const DUPLICATE_INCIDENT_MESSAGE = 'matching dedup key already exists'
 export type TriggerPagerOptions = {
   description: string
   from?: string
-  incidentKey: string
-  serviceId: string
+  incidentKey?: string
+  serviceId?: string
   title: string
-  token: string
+  token?: string
   urgency?: 'low' | 'high'
 }
 

--- a/replace.d.ts
+++ b/replace.d.ts
@@ -1,0 +1,13 @@
+declare module 'replace' {
+  type Options = {
+    regex: string
+    replacement: string
+    paths: string[]
+    recursive: boolean
+    silent: boolean
+  }
+
+  function replace(opts: Options): string
+
+  export = replace
+}

--- a/template-package/package.json
+++ b/template-package/package.json
@@ -21,7 +21,7 @@
     "test": "dist"
   },
   "scripts": {
-    "tsc": "tsc",
+    "tsc": "tsc --build --clean && tsc --build",
     "test": "echo \"Error: run tests from root\" && exit 1"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "lib": ["es6"],
     "types": ["node", "jest"]
   },
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules", "**/*.test.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "target": "es6",
     "sourceMap": true,
     "skipLibCheck": true,
-    "lib": ["es6"],
+    "lib": ["es2022"],
     "types": ["node", "jest"]
   },
   "exclude": ["node_modules", "**/*.test.ts"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1627,6 +1627,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/inflection@npm:^1.13.1":
+  version: 1.13.1
+  resolution: "@types/inflection@npm:1.13.1"
+  checksum: 7f6e667f470e70a9ebcde58fad1d376319ec32dcaada466b3d4108ffd300a0fc167aacf714907309588673b53fd4a1d1a6b4101e24e0c973fc7ec6c0a612088b
+  languageName: node
+  linkType: hard
+
 "@types/inquirer@npm:^8.2.1":
   version: 8.2.9
   resolution: "@types/inquirer@npm:8.2.9"
@@ -7247,6 +7254,7 @@ __metadata:
     "@babel/eslint-parser": "npm:^7.18.9"
     "@babel/eslint-plugin": "npm:^7.18.10"
     "@sucrase/jest-plugin": "npm:^2.2.1"
+    "@types/inflection": "npm:^1.13.1"
     "@types/jest": "npm:^29.0.0"
     "@types/node": "npm:^18.7.14"
     "@typescript-eslint/eslint-plugin": "npm:^5.36.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1470,7 +1470,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@transloadit/has-property@npm:^0.0.0, @transloadit/has-property@workspace:^, @transloadit/has-property@workspace:packages/has-property":
+"@transloadit/has-property@npm:^0.0.0, @transloadit/has-property@workspace:packages/has-property":
   version: 0.0.0-use.local
   resolution: "@transloadit/has-property@workspace:packages/has-property"
   languageName: unknown
@@ -1548,7 +1548,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@transloadit/sort-result-meta@workspace:packages/sort-result-meta"
   dependencies:
-    "@transloadit/has-property": "workspace:^"
+    "@transloadit/has-property": "npm:^0.0.0"
     "@transloadit/sort-object-by-prio": "npm:^0.1.2"
   languageName: unknown
   linkType: soft
@@ -1557,7 +1557,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@transloadit/sort-result@workspace:packages/sort-result"
   dependencies:
-    "@transloadit/has-property": "workspace:^"
+    "@transloadit/has-property": "npm:^0.0.0"
     "@transloadit/sort-object-by-prio": "npm:^0.1.2"
     "@transloadit/sort-result-meta": "npm:^0.1.2"
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -1470,6 +1470,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@transloadit/has-property@npm:^0.0.0, @transloadit/has-property@workspace:^, @transloadit/has-property@workspace:packages/has-property":
+  version: 0.0.0-use.local
+  resolution: "@transloadit/has-property@workspace:packages/has-property"
+  languageName: unknown
+  linkType: soft
+
 "@transloadit/post@workspace:packages/post":
   version: 0.0.0-use.local
   resolution: "@transloadit/post@workspace:packages/post"
@@ -1516,6 +1522,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@transloadit/sort-assembly@workspace:packages/sort-assembly"
   dependencies:
+    "@transloadit/has-property": "npm:^0.0.0"
     "@transloadit/sort-object-by-prio": "npm:^0.1.2"
     "@transloadit/sort-result": "npm:^0.1.2"
   languageName: unknown
@@ -1532,6 +1539,8 @@ __metadata:
 "@transloadit/sort-object@npm:^0.1.2, @transloadit/sort-object@workspace:packages/sort-object":
   version: 0.0.0-use.local
   resolution: "@transloadit/sort-object@workspace:packages/sort-object"
+  dependencies:
+    "@transloadit/has-property": "npm:^0.0.0"
   languageName: unknown
   linkType: soft
 
@@ -1539,6 +1548,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@transloadit/sort-result-meta@workspace:packages/sort-result-meta"
   dependencies:
+    "@transloadit/has-property": "workspace:^"
     "@transloadit/sort-object-by-prio": "npm:^0.1.2"
   languageName: unknown
   linkType: soft
@@ -1547,6 +1557,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@transloadit/sort-result@workspace:packages/sort-result"
   dependencies:
+    "@transloadit/has-property": "workspace:^"
     "@transloadit/sort-object-by-prio": "npm:^0.1.2"
     "@transloadit/sort-result-meta": "npm:^0.1.2"
   languageName: unknown


### PR DESCRIPTION
- Improves types across the repo, get rid of all `$TSFixMe` and most `any`
- enable typescript-eslint plugin, 
- add a new package `has-property` that helps with narrowing non-descript objects `Record<string, unknown>` to an object that actually contains a key: `{ meta: unknown }`, useful in many other packages in the repo.
- stop transpiling and distributing test files

