### PR TITLE
Use composite, incremental, project references

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+tsconfig.tsbuildinfo

--- a/packages/abbr/tsconfig.json
+++ b/packages/abbr/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "dist/",
+    "rootDir": "src/"
   },
-  "include": ["./src"]
+  "include": ["src/"]
 }

--- a/packages/analyze-step/tsconfig.json
+++ b/packages/analyze-step/tsconfig.json
@@ -1,7 +1,13 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "dist/",
+    "rootDir": "src/",
+    "paths": {
+      "@transloadit/format-duration-ms": ["../format-duration-ms"],
+      "@transloadit/prettier-bytes": ["../prettier-bytes"]
+    }
   },
-  "include": ["./src"]
+  "references": [{ "path": "../format-duration-ms" }, { "path": "../prettier-bytes" }],
+  "include": ["src/"]
 }

--- a/packages/enrich-tweet/src/enrichTweet.ts
+++ b/packages/enrich-tweet/src/enrichTweet.ts
@@ -13,7 +13,7 @@ async function tryUnshorten(url: string, unshorten: boolean): Promise<string> {
 }
 
 type Tweet = {
-  full_text: string
+  full_text?: string
   entities?: {
     urls: {
       display_url: string

--- a/packages/enrich-tweet/tsconfig.json
+++ b/packages/enrich-tweet/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "dist/",
+    "rootDir": "src/"
   },
-  "include": ["./src"]
+  "include": ["src/"]
 }

--- a/packages/file-exists/tsconfig.json
+++ b/packages/file-exists/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "dist/",
+    "rootDir": "src/"
   },
-  "include": ["./src"]
+  "include": ["src/"]
 }

--- a/packages/format-duration-ms/tsconfig.json
+++ b/packages/format-duration-ms/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "dist/",
+    "rootDir": "src/"
   },
-  "include": ["./src"]
+  "include": ["src/"]
 }

--- a/packages/has-property/tsconfig.json
+++ b/packages/has-property/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "dist/",
+    "rootDir": "src/"
   },
-  "include": ["./src"]
+  "include": ["src/"]
 }

--- a/packages/post/src/post.ts
+++ b/packages/post/src/post.ts
@@ -7,10 +7,9 @@ import openInEditor from 'open-in-editor'
 import fileExists from '@transloadit/file-exists'
 import slugify from '@transloadit/slugify'
 import title from 'title'
-import packageJson from '../package.json'
 
 async function post(): Promise<void> {
-  console.log(`Welcome to @transloadit/post@${packageJson.version}. `)
+  console.log(`Welcome to @transloadit/post.`)
   console.log(`Please answer some questions about the blog post, `)
   console.log(`and I'll generate a starting point and open your editor. `)
 

--- a/packages/post/tsconfig.json
+++ b/packages/post/tsconfig.json
@@ -1,8 +1,14 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist",
-    "resolveJsonModule": true
+    "outDir": "dist/",
+    "resolveJsonModule": true,
+    "rootDir": "src/",
+    "paths": {
+      "@transloadit/file-exists": ["../file-exists"],
+      "@transloadit/slugify": ["../slugify"]
+    }
   },
-  "include": ["./src"]
+  "references": [{ "path": "../file-exists" }, { "path": "../slugify" }],
+  "include": ["src/"]
 }

--- a/packages/pr/tsconfig.json
+++ b/packages/pr/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "dist/",
+    "rootDir": "src/"
   },
-  "include": ["./src"]
+  "include": ["src/"]
 }

--- a/packages/prd/tsconfig.json
+++ b/packages/prd/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "dist/",
+    "rootDir": "src/"
   },
-  "include": ["./src"]
+  "include": ["src/"]
 }

--- a/packages/prettier-bytes/tsconfig.json
+++ b/packages/prettier-bytes/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "dist/",
+    "rootDir": "src/"
   },
-  "include": ["./src"]
+  "include": ["src/"]
 }

--- a/packages/slugify/tsconfig.json
+++ b/packages/slugify/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "dist/",
+    "rootDir": "src/"
   },
-  "include": ["./src"]
+  "include": ["src/"]
 }

--- a/packages/sort-assembly/tsconfig.json
+++ b/packages/sort-assembly/tsconfig.json
@@ -1,7 +1,18 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "dist/",
+    "rootDir": "src/",
+    "paths": {
+      "@transloadit/has-property": ["../has-property"],
+      "@transloadit/sort-object-by-prio": ["../sort-object-by-prio"],
+      "@transloadit/sort-result": ["../sort-result"]
+    }
   },
-  "include": ["./src"]
+  "references": [
+    { "path": "../has-property" },
+    { "path": "../sort-object-by-prio" },
+    { "path": "../sort-result" }
+  ],
+  "include": ["src/"]
 }

--- a/packages/sort-object-by-prio/tsconfig.json
+++ b/packages/sort-object-by-prio/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "dist/",
+    "rootDir": "src/",
+    "paths": {
+      "@transloadit/has-property": ["../sort-object"]
+    }
   },
-  "include": ["./src"]
+  "references": [{ "path": "../sort-object" }],
+  "include": ["src/"]
 }

--- a/packages/sort-object/tsconfig.json
+++ b/packages/sort-object/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "dist/",
+    "rootDir": "src/",
+    "paths": {
+      "@transloadit/has-property": ["../has-property"]
+    }
   },
-  "include": ["./src"]
+  "references": [{ "path": "../has-property" }],
+  "include": ["src/"]
 }

--- a/packages/sort-result-meta/tsconfig.json
+++ b/packages/sort-result-meta/tsconfig.json
@@ -1,7 +1,13 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "dist/",
+    "rootDir": "src/",
+    "paths": {
+      "@transloadit/has-property": ["../has-property"],
+      "@transloadit/sort-object-by-prio": ["../sort-object-by-prio"]
+    }
   },
-  "include": ["./src"]
+  "references": [{ "path": "../has-property" }, { "path": "../sort-object-by-prio" }],
+  "include": ["src/"]
 }

--- a/packages/sort-result/tsconfig.json
+++ b/packages/sort-result/tsconfig.json
@@ -1,7 +1,18 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "dist/",
+    "rootDir": "src/",
+    "paths": {
+      "@transloadit/has-property": ["../has-property"],
+      "@transloadit/sort-object-by-prio": ["../sort-object-by-prio"],
+      "@transloadit/sort-result": ["../sort-result-meta"]
+    }
   },
-  "include": ["./src"]
+  "references": [
+    { "path": "../has-property" },
+    { "path": "../sort-object-by-prio" },
+    { "path": "../sort-result-meta" }
+  ],
+  "include": ["src/"]
 }

--- a/packages/trigger-pager/tsconfig.json
+++ b/packages/trigger-pager/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "dist/",
+    "rootDir": "src/"
   },
-  "include": ["./src"]
+  "include": ["src/"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,9 @@
     "sourceMap": true,
     "skipLibCheck": true,
     "lib": ["es2022"],
-    "types": ["node", "jest"]
+    "types": ["node", "jest"],
+    "composite": true,
+    "incremental": true
   },
   "exclude": ["node_modules", "**/*.test.ts"]
 }


### PR DESCRIPTION
- The `composite option` enforces certain constraints which make it possible for build tools (including TypeScript itself, under --build mode) to quickly determine if a project has been built yet.
- `incremental` tells TypeScript to save information about the project graph from the last compilation to files stored on disk that can be used to speed up subsequent builds. This creates a series of .tsbuildinfo files in the same folder as your compilation output.
- Project `references` are a way to structure your TypeScript programs into smaller pieces. Using Project References can greatly improve build and editor interaction times, enforce logical separation between components, and organize your code in new and improved ways.
- `paths` helps TS to resolve local dependencies directly