### PR TITLE
Use TS CommonJS modules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
     'no-restricted-globals': ['warn'],
     'no-restricted-properties': ['warn'],
     'no-restricted-syntax': ['warn'],
+    'import/no-unresolved': ['error', { commonjs: true }],
     'import/extensions': [
       'error',
       'ignorePackages',
@@ -46,5 +47,6 @@ module.exports = {
         tsx: 'never',
       },
     ],
+    '@typescript-eslint/no-var-requires': 'off',
   },
 }

--- a/packages/abbr/src/abbr.test.ts
+++ b/packages/abbr/src/abbr.test.ts
@@ -1,7 +1,7 @@
 import { describe, test } from 'node:test'
 import assert from 'node:assert'
 
-import abbr from './abbr'
+const abbr = require('./abbr')
 
 describe('abbr', () => {
   test('main', async () => {

--- a/packages/abbr/src/abbr.test.ts
+++ b/packages/abbr/src/abbr.test.ts
@@ -1,7 +1,7 @@
 import { describe, test } from 'node:test'
 import assert from 'node:assert'
 
-const abbr = require('./abbr')
+import abbr from './abbr'
 
 describe('abbr', () => {
   test('main', async () => {

--- a/packages/abbr/src/abbr.ts
+++ b/packages/abbr/src/abbr.ts
@@ -1,4 +1,4 @@
-module.exports = function abbr(str: string, maxLength = 55, divider = `[...]`): string {
+export = function abbr(str: string, maxLength = 55, divider = `[...]`): string {
   if (str !== `${str}`) {
     return str
   }

--- a/packages/abbr/src/abbr.ts
+++ b/packages/abbr/src/abbr.ts
@@ -1,4 +1,4 @@
-export default function abbr(str: string, maxLength = 55, divider = `[...]`): string {
+module.exports = function abbr(str: string, maxLength = 55, divider = `[...]`): string {
   if (str !== `${str}`) {
     return str
   }

--- a/packages/analyze-step/src/analyzeStep.test.ts
+++ b/packages/analyze-step/src/analyzeStep.test.ts
@@ -2,7 +2,6 @@
 import { describe, test } from 'node:test'
 import assert from 'node:assert'
 import analyzeStep from './analyzeStep'
-// const util = require('util')
 
 const ROBOTS = {
   '/image/resize': {

--- a/packages/analyze-step/src/analyzeStep.ts
+++ b/packages/analyze-step/src/analyzeStep.ts
@@ -312,7 +312,7 @@ type Step = Partial<FileFilterStep> &
     [key: string]: any
   }
 
-function humanize(step: Step, robots: Robots, extrameta: ExtraMeta = {}): string {
+export = function humanize(step: Step, robots: Robots, extrameta: ExtraMeta = {}): string {
   let str = ``
 
   const robot = robots[step.robot]
@@ -439,5 +439,3 @@ function humanize(step: Step, robots: Robots, extrameta: ExtraMeta = {}): string
 
   return str
 }
-
-export = humanize

--- a/packages/analyze-step/src/analyzeStep.ts
+++ b/packages/analyze-step/src/analyzeStep.ts
@@ -1,10 +1,13 @@
 /* eslint-disable quote-props */
 /* eslint-disable no-template-curly-in-string */
-import formatDurationMs from '@transloadit/format-duration-ms'
-import prettierBytes from '@transloadit/prettier-bytes'
-import * as inflect from 'inflection'
-import { JSONPath } from 'jsonpath-plus'
-import { clone, countBy, get, has } from 'lodash'
+import formatDurationMs = require('@transloadit/format-duration-ms')
+import prettierBytes = require('@transloadit/prettier-bytes')
+import inflect = require('inflection')
+import JSONPath = require('jsonpath-plus')
+import clone = require('lodash/clone')
+import countBy = require('lodash/countBy')
+import get = require('lodash/get')
+import has = require('lodash/has')
 
 function humanJoin(array: string[], reduce = true, glueword = 'and'): string {
   let countedArray = array
@@ -309,7 +312,7 @@ type Step = Partial<FileFilterStep> &
     [key: string]: any
   }
 
-export default function humanize(step: Step, robots: Robots, extrameta: ExtraMeta = {}): string {
+function humanize(step: Step, robots: Robots, extrameta: ExtraMeta = {}): string {
   let str = ``
 
   const robot = robots[step.robot]
@@ -395,7 +398,7 @@ export default function humanize(step: Step, robots: Robots, extrameta: ExtraMet
   }
 
   if (robot?.rname === '/video/merge') {
-    const types = JSONPath({ path: '$..as', json: step })
+    const types = JSONPath.JSONPath({ path: '$..as', json: step })
     if (types.length) {
       str = `Merge ${humanJoin(types)} to create a new video`
     } else if (get(step, 'ffmpeg.f') === 'gif') {
@@ -436,3 +439,5 @@ export default function humanize(step: Step, robots: Robots, extrameta: ExtraMet
 
   return str
 }
+
+export = humanize

--- a/packages/enrich-tweet/src/enrichTweet.ts
+++ b/packages/enrich-tweet/src/enrichTweet.ts
@@ -1,12 +1,12 @@
-import twttr from 'twitter-text'
-import { tall } from 'tall'
+import twttr = require('twitter-text')
+import tall = require('tall')
 
-import getUrls from 'get-urls'
+import getUrls = require('get-urls')
 
 async function tryUnshorten(url: string, unshorten: boolean): Promise<string> {
   if (!unshorten) return url
   try {
-    return await tall(url)
+    return await tall.tall(url)
   } catch (err) {
     return url
   }
@@ -32,10 +32,7 @@ type Tweet = {
   }
 }
 
-export default async function enrichTweet(
-  tweet: Tweet,
-  unshorten = true
-): Promise<string | undefined> {
+export = async function enrichTweet(tweet: Tweet, unshorten = true): Promise<string | undefined> {
   if (!tweet) return
 
   let text = tweet.full_text ?? ''

--- a/packages/file-exists/src/fileExists.ts
+++ b/packages/file-exists/src/fileExists.ts
@@ -1,6 +1,6 @@
-import fs from 'fs'
+import fs = require('fs')
 
-export default function fileExists(path: string): Promise<boolean> {
+export = function fileExists(path: string): Promise<boolean> {
   return new Promise((resolve) => {
     fs.access(path, fs.constants.F_OK, (err) => {
       resolve(!err)

--- a/packages/format-duration-ms/src/formatDurationMs.ts
+++ b/packages/format-duration-ms/src/formatDurationMs.ts
@@ -1,6 +1,6 @@
-import prettyMS from 'pretty-ms'
+import prettyMS = require('pretty-ms')
 
-export default function formatDurationMs(ms: number): string {
+export = function formatDurationMs(ms: number): string {
   let human = prettyMS(ms)
 
   human = human.replace(/(\d+)\.\d+s/g, '$1s')

--- a/packages/has-property/src/has-property.test.ts
+++ b/packages/has-property/src/has-property.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test'
 import assert from 'node:assert'
-import { hasProperty } from './has-property'
+import hasProperty from './has-property'
 
 test('hasProperty', () => {
   assert.ok(hasProperty({ foo: 'bar' }, 'foo'))

--- a/packages/has-property/src/has-property.ts
+++ b/packages/has-property/src/has-property.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/prefer-default-export
-export function hasProperty<K extends PropertyKey>(
+export = function hasProperty<K extends PropertyKey>(
   obj: unknown,
   key: K | null | undefined
 ): obj is Record<K, unknown> {

--- a/packages/post/src/post.ts
+++ b/packages/post/src/post.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
-import { promises as fs } from 'fs'
-import inquirer from 'inquirer'
+import fs = require('fs/promises')
+import inquirer = require('inquirer')
 
-import openInEditor from 'open-in-editor'
-import fileExists from '@transloadit/file-exists'
-import slugify from '@transloadit/slugify'
-import title from 'title'
+import openInEditor = require('open-in-editor')
+import fileExists = require('@transloadit/file-exists')
+import slugify = require('@transloadit/slugify')
+import title = require('title')
 
 async function post(): Promise<void> {
   console.log(`Welcome to @transloadit/post.`)

--- a/packages/pr/src/pr.ts
+++ b/packages/pr/src/pr.ts
@@ -1,6 +1,6 @@
-import * as util from 'util'
+import util = require('util')
 
-export default function pr<T>(...args: T[]): T[] {
+export = function pr<T>(...args: T[]): T[] {
   for (const arg of args) {
     console.log(util.inspect(arg, false, null, true))
   }

--- a/packages/prd/src/prd.ts
+++ b/packages/prd/src/prd.ts
@@ -1,6 +1,6 @@
-import pr from '@transloadit/pr'
+import pr = require('@transloadit/pr')
 
-export default function prd<T>(...args: T[]): void {
+export = function prd<T>(...args: T[]): void {
   pr(...args)
   const err = new Error('Halt via prd')
   console.error(err)

--- a/packages/prd/tsconfig.json
+++ b/packages/prd/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist/",
-    "rootDir": "src/"
+    "rootDir": "src/",
+    "paths": {
+      "@transloadit/pr": ["../pr"]
+    }
   },
-  "include": ["src/"]
+  "include": ["src/"],
+  "references": [{ "path": "../pr" }]
 }

--- a/packages/prettier-bytes/src/prettierBytes.ts
+++ b/packages/prettier-bytes/src/prettierBytes.ts
@@ -1,7 +1,7 @@
 // Adapted from https://github.com/Flet/prettier-bytes/
 // Changing 1000 bytes to 1024, so we can keep uppercase KB vs kB
 // ISC License (c) Dan Flettre https://github.com/Flet/prettier-bytes/blob/master/LICENSE
-export default function prettierBytes(num: number): string {
+export = function prettierBytes(num: number): string {
   if (typeof num !== 'number' || Number.isNaN(num)) {
     throw new TypeError(`Expected a number, got ${typeof num}`)
   }

--- a/packages/slugify/src/slugify.ts
+++ b/packages/slugify/src/slugify.ts
@@ -1,4 +1,4 @@
-export default function slugify(str: string): string {
+export = function slugify(str: string): string {
   if (!str || str !== `${str}`) return str
 
   return str

--- a/packages/sort-assembly/src/sortAssembly.ts
+++ b/packages/sort-assembly/src/sortAssembly.ts
@@ -1,8 +1,8 @@
-import sortObjectByPrio from '@transloadit/sort-object-by-prio'
-import sortResult from '@transloadit/sort-result'
-import { hasProperty } from '@transloadit/has-property'
+import sortObjectByPrio = require('@transloadit/sort-object-by-prio')
+import sortResult = require('@transloadit/sort-result')
+import hasProperty = require('@transloadit/has-property')
 
-export default function sortAssembly<T extends Record<string, unknown>>(assembly: T): T {
+export = function sortAssembly<T extends Record<string, unknown>>(assembly: T): T {
   const sorted = sortObjectByPrio(assembly, {
     _: ['assembly_id', 'ok', 'message', 'warnings', 'error'],
     z: ['uploads', 'results'],

--- a/packages/sort-object-by-prio/src/sortObjectByPrio.ts
+++ b/packages/sort-object-by-prio/src/sortObjectByPrio.ts
@@ -1,10 +1,10 @@
-import sortObject from '@transloadit/sort-object'
+import sortObject = require('@transloadit/sort-object')
 
 type Prefixes = {
   [prefix: string]: Array<string | RegExp>
 }
 
-export default function sortObjectByPrio<T extends Record<string, unknown>>(
+export = function sortObjectByPrio<T extends Record<string, unknown>>(
   obj: T,
   prefixes: Prefixes
 ): T {

--- a/packages/sort-object/src/sortObject.ts
+++ b/packages/sort-object/src/sortObject.ts
@@ -1,4 +1,4 @@
-export default function sortObject<T extends Record<string, unknown>>(
+export = function sortObject<T extends Record<string, unknown>>(
   obj: T,
   // eslint-disable-next-line no-unused-vars
   sortFunc?: (a: string, b: string) => number

--- a/packages/sort-result-meta/src/sortResultMeta.ts
+++ b/packages/sort-result-meta/src/sortResultMeta.ts
@@ -1,4 +1,4 @@
-import sortObjectByPrio from '@transloadit/sort-object-by-prio'
+import sortObjectByPrio = require('@transloadit/sort-object-by-prio')
 
 type Meta = {
   faces?: Record<string, unknown>[]
@@ -10,7 +10,7 @@ function isObject(obj: unknown): obj is Record<string, unknown> {
   )
 }
 
-export default function sortResultMeta<T extends Meta>(meta: T): T {
+export = function sortResultMeta<T extends Meta>(meta: T): T {
   if (meta.faces) {
     for (let i = 0; i < meta.faces.length; i++) {
       const el = meta.faces[i]

--- a/packages/sort-result/src/sortResult.ts
+++ b/packages/sort-result/src/sortResult.ts
@@ -1,7 +1,7 @@
-import sortObjectByPrio from '@transloadit/sort-object-by-prio'
-import sortResultMeta from '@transloadit/sort-result-meta'
+import sortObjectByPrio = require('@transloadit/sort-object-by-prio')
+import sortResultMeta = require('@transloadit/sort-result-meta')
 
-export default function sortResult<T extends { meta?: unknown }>(result: T): T {
+export = function sortResult<T extends { meta?: unknown }>(result: T): T {
   const sorted = sortObjectByPrio(result, {
     _: ['id'],
     z: ['meta'],

--- a/packages/trigger-pager/src/triggerPager.test.ts
+++ b/packages/trigger-pager/src/triggerPager.test.ts
@@ -35,7 +35,7 @@ mockRequire('@pagerduty/pdjs', () => {
   return { api: () => ({ post: mockPost }) }
 })
 
-const { default: triggerPager } = require('./triggerPager')
+const triggerPager = require('./triggerPager')
 
 const LOREM_LONG = `Lorem ipsum dolor sit amet, consectetur adipiscing elit,
 sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

--- a/packages/trigger-pager/src/triggerPager.ts
+++ b/packages/trigger-pager/src/triggerPager.ts
@@ -1,9 +1,9 @@
-import { api } from '@pagerduty/pdjs'
+import pagerduty = require('@pagerduty/pdjs')
 
 const PRIORITY_P1 = 'PUTY3A1'
 const DUPLICATE_INCIDENT_MESSAGE = 'matching dedup key already exists'
 
-export type TriggerPagerOptions = {
+type TriggerPagerOptions = {
   description: string
   from?: string
   incidentKey: string
@@ -22,7 +22,7 @@ const triggerPager = async ({
   token,
   urgency = 'high',
 }: TriggerPagerOptions): Promise<void> => {
-  const res = await api({ token }).post('/incidents', {
+  const res = await pagerduty.api({ token }).post('/incidents', {
     headers: {
       from,
     },
@@ -58,4 +58,4 @@ const triggerPager = async ({
   }
 }
 
-export default triggerPager
+export = triggerPager

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "esModuleInterop": true,
     "lib": ["ES2023"],
     "target": "es2022",
-    "module": "commonjs",
+    "module": "nodenext",
     "verbatimModuleSyntax": true,
 
     "forceConsistentCasingInFileNames": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "compilerOptions": {
     "esModuleInterop": true,
-    "lib": ["es2022"],
+    "lib": ["ES2023"],
     "target": "es2022",
     "module": "commonjs",
+    "verbatimModuleSyntax": true,
 
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,


### PR DESCRIPTION
After some recent build errors in our CI, I think we should use plain CJS here until we support ESM in the API repo. This will make sure TS doesn't inject any compatibility code and compiles to simple CJS.

Docs to understand why `nodenext`: https://www.typescriptlang.org/docs/handbook/modules/reference.html#node16-nodenext

And the weird `export = ...` and `import ... = require(...)`: https://www.typescriptlang.org/docs/handbook/modules/reference.html#export--and-import--require

**Before**

CJS with compatibility code:

<img width="837" alt="Screenshot 2024-01-16 at 17 04 13" src="https://github.com/transloadit/monolib/assets/2504906/574017cb-f6c9-4ccb-bfcf-02774b2a3813">

**After**

Plain CJS

<img width="737" alt="Screenshot 2024-01-16 at 17 03 56" src="https://github.com/transloadit/monolib/assets/2504906/f79f3f6a-7134-464d-b277-58ae3afa0d4b">
