### PR TITLE
@transloadit/enrich-tweet: use dynamic import to fix build

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "lint:formatting": "prettier --check .",
     "lint:js": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:ts": "lerna run tsc",
-    "new": "sucrase-node new.ts",
-    "pub": "npm-run-all test lernaPublish",
+    "new": "ts-fly new.ts",
+    "pub": "npm-run-all build test lernaPublish",
     "test": "node -r @transloadit/ts-fly --test packages/**/*.test.ts",
     "test:watch": "node -r @transloadit/ts-fly --test --watch packages/**/*.test.ts"
   },

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "lint:ts": "lerna run tsc",
     "new": "sucrase-node new.ts",
     "pub": "npm-run-all test lernaPublish",
-    "test": "node -r sucrase/register --test packages/**/*.test.ts",
-    "test:watch": "node -r sucrase/register --test --watch packages/**/*.test.ts"
+    "test": "node -r @transloadit/ts-fly --test packages/**/*.test.ts",
+    "test:watch": "node -r @transloadit/ts-fly --test --watch packages/**/*.test.ts"
   },
   "dependencies": {
     "execa": "5.1.1",
@@ -27,6 +27,7 @@
     "replace": "1.2.2"
   },
   "devDependencies": {
+    "@transloadit/ts-fly": "^0.1.5",
     "@types/node": "^20.12.6",
     "@typescript-eslint/eslint-plugin": "^7.6.0",
     "@typescript-eslint/parser": "^7.6.0",
@@ -48,7 +49,6 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^3.2.5",
     "prettier-plugin-packagejson": "^2.4.14",
-    "sucrase": "^3.35.0",
     "typescript": "^5.4.4"
   },
   "packageManager": "yarn@4.0.1+sha224.ca5d6f5a8aecd0801adc32f775675b01961bdc2383867d36f4732a0a",

--- a/packages/enrich-tweet/src/enrichTweet.ts
+++ b/packages/enrich-tweet/src/enrichTweet.ts
@@ -1,8 +1,6 @@
 import twttr = require('twitter-text')
 import tall = require('tall')
 
-import getUrls = require('get-urls')
-
 async function tryUnshorten(url: string, unshorten: boolean): Promise<string> {
   if (!unshorten) return url
   try {
@@ -64,6 +62,7 @@ export = async function enrichTweet(tweet: Tweet, unshorten = true): Promise<str
     }
   }
 
+  const getUrls = (await import('get-urls')).default
   const urls = getUrls(text)
   for (const subUrl3 of urls) {
     if (!subUrl3.match(/^https?:\/\/bit\.ly/)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -910,6 +910,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@transloadit/ts-fly@npm:^0.1.5":
+  version: 0.1.5
+  resolution: "@transloadit/ts-fly@npm:0.1.5"
+  dependencies:
+    pirates: "npm:^4.0.5"
+    sucrase: "npm:^3.32.0"
+  bin:
+    ts-fly: ./bin/ts-fly
+  checksum: 480bf053c46b0d3f94ecd54a8140ab7c6f5e6241967cfe208792b0bf1aff9675c604859692c7022ed5df89fa0ea1e6782a7f12df78e9098d7adc48a7f291c252
+  languageName: node
+  linkType: hard
+
 "@tufjs/canonical-json@npm:1.0.0":
   version: 1.0.0
   resolution: "@tufjs/canonical-json@npm:1.0.0"
@@ -5570,6 +5582,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "monolib@workspace:."
   dependencies:
+    "@transloadit/ts-fly": "npm:^0.1.5"
     "@types/node": "npm:^20.12.6"
     "@typescript-eslint/eslint-plugin": "npm:^7.6.0"
     "@typescript-eslint/parser": "npm:^7.6.0"
@@ -5595,7 +5608,6 @@ __metadata:
     prettier: "npm:^3.2.5"
     prettier-plugin-packagejson: "npm:^2.4.14"
     replace: "npm:1.2.2"
-    sucrase: "npm:^3.35.0"
     typescript: "npm:^5.4.4"
   languageName: unknown
   linkType: soft
@@ -6626,7 +6638,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pirates@npm:^4.0.1":
+"pirates@npm:^4.0.1, pirates@npm:^4.0.5":
   version: 4.0.6
   resolution: "pirates@npm:4.0.6"
   checksum: 00d5fa51f8dded94d7429700fb91a0c1ead00ae2c7fd27089f0c5b63e6eca36197fe46384631872690a66f390c5e27198e99006ab77ae472692ab9c2ca903f36
@@ -7752,7 +7764,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sucrase@npm:^3.35.0":
+"sucrase@npm:^3.32.0":
   version: 3.35.0
   resolution: "sucrase@npm:3.35.0"
   dependencies:


### PR DESCRIPTION
Without this change, running `yarn build` on latest `main`:

```
   ✖  @transloadit/enrich-tweet:tsc
      src/enrichTweet.ts(4,26): error TS1471: Module 'get-urls' cannot be imported using this construct. The specifier only resolves to an ES module, which cannot be imported with 'require'. Use an ECMAScript import instead.
      src/enrichTweet.ts(67,16): error TS2349: This expression is not callable.
        Type 'typeof import("/Users/merlijnvos/code/monolib/node_modules/get-urls/index", { with: { "resolution-mode": "import" } })' has no call signatures.
```