### PR TITLE
Improve SevLogger ergonomics

### DIFF
--- a/.changeset/clever-clickables-shorthand.md
+++ b/.changeset/clever-clickables-shorthand.md
@@ -1,0 +1,7 @@
+---
+'@transloadit/sev-logger': patch
+---
+
+- Fix clickable path fallback so non-TTY logs print clean relative paths instead of repeated `file:///` segments.
+- Update shared padding to grow only when a log line is actually emitted, preventing indentation from jumping when suppressed nested loggers exist.
+- Add shorthand overloads for `nest()` so callers can pass a single string or array of breadcrumbs without wrapping them in an object.

--- a/packages/sev-logger/src/SevLogger.test.ts
+++ b/packages/sev-logger/src/SevLogger.test.ts
@@ -82,6 +82,38 @@ const plainFormatColors = {
 } as const
 
 describe('SevLogger', () => {
+  describe('nest shorthand', () => {
+    const createBaseLogger = () =>
+      new SevLogger({
+        level: LEVEL.INFO,
+        breadcrumbs: ['root'],
+        colors: plainColors,
+        levelColors: plainLevelColors,
+        formatColors: plainFormatColors,
+        addCallsite: false,
+      })
+
+    it('accepts a single breadcrumb string', () => {
+      const childLogger = createBaseLogger().nest('child')
+
+      assert.strictEqual(childLogger.formatter(LEVEL.INFO, 'hi'), 'root:child [   INFO] hi')
+    })
+
+    it('accepts an array of breadcrumbs', () => {
+      const branchLogger = createBaseLogger().nest(['child', 'leaf'])
+
+      assert.strictEqual(branchLogger.formatter(LEVEL.INFO, 'hi'), 'root:child:leaf [   INFO] hi')
+    })
+
+    it('merges shorthand breadcrumbs with additional params', () => {
+      const branchLogger = createBaseLogger().nest('child', {
+        breadcrumbs: ['leaf'],
+        nestDivider: '>',
+      })
+
+      assert.strictEqual(branchLogger.formatter(LEVEL.INFO, 'hi'), 'root>child>leaf [   INFO] hi')
+    })
+  })
   describe('shared padding', () => {
     it('does not expand breadcrumb padding for suppressed nested logs', () => {
       const root = new SevLogger({

--- a/packages/sev-logger/src/SevLogger.ts
+++ b/packages/sev-logger/src/SevLogger.ts
@@ -1043,7 +1043,28 @@ export class SevLogger {
   }
 
   /** Creates a new logger instance nested within the current one. */
-  nest(params: SevLoggerParams = {}) {
+  nest(breadcrumb: string, params?: SevLoggerParams): SevLogger
+  nest(breadcrumbs: string[], params?: SevLoggerParams): SevLogger
+  nest(params?: SevLoggerParams): SevLogger
+  nest(
+    breadcrumbsOrParams?: string | string[] | SevLoggerParams,
+    maybeParams?: SevLoggerParams,
+  ): SevLogger {
+    let params: SevLoggerParams
+    if (typeof breadcrumbsOrParams === 'string') {
+      params = {
+        ...(maybeParams ?? {}),
+        breadcrumbs: [breadcrumbsOrParams, ...(maybeParams?.breadcrumbs ?? [])],
+      }
+    } else if (Array.isArray(breadcrumbsOrParams)) {
+      params = {
+        ...(maybeParams ?? {}),
+        breadcrumbs: [...breadcrumbsOrParams, ...(maybeParams?.breadcrumbs ?? [])],
+      }
+    } else {
+      params = (breadcrumbsOrParams ?? maybeParams ?? {}) as SevLoggerParams
+    }
+
     const currentLevelRawBreadcrumbs = params.breadcrumbs ?? []
     return new SevLogger({
       ...this.#params,


### PR DESCRIPTION
## Summary
- add shorthand overloads for `nest()` so a string or array can be passed directly
- keep clickable path fallback readable on non-TTY streams and gate padding growth on visible logs
- cover the new behavior with tests and a changeset