### PR TITLE
ci: use Node 24 for release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,14 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@^11.5.1
+      - name: Verify npm for trusted publishing
+        run: |
+          version="$(npm --version)"
+          echo "npm ${version}"
+          node -e "const version = process.argv[1]; const [major, minor, patch] = version.split('.').map(Number); if (major < 11 || (major === 11 && (minor < 5 || (minor === 5 && patch < 1)))) { throw new Error('npm 11.5.1 or newer is required for trusted publishing'); }" "$version"
 
       - name: 🏗 Setup Caching
         uses: actions/cache@v4


### PR DESCRIPTION
Why

The main-branch Release workflow is failing before it reaches project install because the hosted Node 22 npm installation is missing its own promise-retry module while trying to run npm install -g npm@^11.5.1. The already-merged package versions need the next main push to publish @transloadit/analyze-step@1.0.1 and @transloadit/post@1.0.1.

What changed

- Run the release job on Node 24 so the trusted-publishing-compatible npm is provided by the toolchain.
- Replace the self-upgrade step with a version assertion for npm >= 11.5.1.

Validation

- git diff --check
