### PR TITLE
Harden dependency installs

### DIFF
--- a/.github/workflows/ci-monolib.yml
+++ b/.github/workflows/ci-monolib.yml
@@ -40,6 +40,6 @@ jobs:
             ${{ runner.os }}-
 
       - run: corepack yarn config set enableHardenedMode false
-      - run: corepack yarn install
+      - run: corepack yarn install --immutable
 
       - run: corepack yarn check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,16 +44,6 @@ jobs:
           echo "npm ${version}"
           node -e "const version = process.argv[1]; const [major, minor, patch] = version.split('.').map(Number); if (major < 11 || (major === 11 && (minor < 5 || (minor === 5 && patch < 1)))) { throw new Error('npm 11.5.1 or newer is required for trusted publishing'); }" "$version"
 
-      - name: 🏗 Setup Caching
-        uses: actions/cache@v4
-        with:
-          path: |
-            **/node_modules
-            .yarn/cache
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock', '**/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-
-
       # Allow yarn to make changes during release
       - run: corepack yarn config set enableHardenedMode false
       - run: corepack yarn --mode=update-lockfile

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,3 +3,5 @@ enableGlobalCache: true
 nodeLinker: node-modules
 
 npmRegistryServer: "https://registry.npmjs.org"
+
+npmMinimalAgeGate: 2880

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "npm-run-all": "^4.1.5",
     "typescript": "^5.9.3"
   },
-  "packageManager": "yarn@4.9.4",
+  "packageManager": "yarn@4.12.0",
   "engines": {
     "node": ">= 18",
     "yarn": "4.2.1"


### PR DESCRIPTION
## Why
Recent npm supply-chain compromises showed that dependency installs and shared CI caches can execute or preserve newly published malicious packages before advisories catch up. This PR reduces that exposure for this repo.

## What changed
- Upgraded Yarn to 4.12.0, added the minimal age gate, made CI installs immutable, and removed dependency caching from the release workflow.

## Validation
- Ran `git diff --check` across the prepared worktree.
- Audited this PR set for `pull_request_target` and release/deploy/CDN cache reuse; patched actionable hits.
- Did not run the full test suite; this is a workflow/config-only change.