### PR TITLE
fix: handle sev logger esm callsites

### DIFF
--- a/packages/sev-logger/CHANGELOG.md
+++ b/packages/sev-logger/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @transloadit/sev-logger
 
+## 1.0.1
+
+### Patch Changes
+
+- Fix ESM callsite detection so logging from file URL stack frames does not throw at runtime.
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/sev-logger/package.json
+++ b/packages/sev-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transloadit/sev-logger",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "repository": {
     "type": "git",
     "url": "git://github.com/transloadit/monolib.git",

--- a/packages/sev-logger/src/SevLogger.test.ts
+++ b/packages/sev-logger/src/SevLogger.test.ts
@@ -336,6 +336,30 @@ describe('SevLogger', () => {
       // Check if the callsite pattern exists somewhere in the formatted string
       assert.match(formatted, expectedPattern)
     })
+
+    it('logs with ESM callsite detection enabled', () => {
+      let output = ''
+      const stdout = {
+        columns: 120,
+        isTTY: false,
+        write: (chunk: string) => {
+          output += chunk
+          return true
+        },
+      }
+      const logger = new SevLogger({
+        level: LEVEL.TRACE,
+        addCallsite: true,
+        colors: plainColors,
+        levelColors: plainLevelColors,
+        formatColors: plainFormatColors,
+        stdout: stdout as unknown as NodeJS.WriteStream,
+      })
+
+      assert.doesNotThrow(() => logger.notice('notice smoke %s', 'ok'))
+      assert.match(output, /notice smoke ok/)
+      assert.match(output, /SevLogger\.test\.(js|ts):\d+/)
+    })
   })
 
   describe('announceMotd', () => {

--- a/packages/sev-logger/src/SevLogger.ts
+++ b/packages/sev-logger/src/SevLogger.ts
@@ -1,11 +1,14 @@
 import fs from 'node:fs'
 import { hostname, userInfo } from 'node:os'
 import path, { basename, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { inspect } from 'node:util'
 import { abbr } from '@transloadit/abbr'
 
 export const normalizeCallsitePath = (filePath: string) =>
   filePath.startsWith('file://') ? fileURLToPath(filePath) : filePath
+
+const moduleFilepath = import.meta.filename
 
 const GENERIC_TOKEN_PATTERN = /\b[A-Za-z0-9+=]{32,}\b/g
 const GENERIC_SLASHY_TOKEN_PATTERN = /[A-Za-z0-9+/=]{32,}/g
@@ -176,32 +179,11 @@ export class SevLogger {
   // Initialize static member directly
   static #crcTable: number[] | null = null
 
-  static #pathFromStack() {
-    // A getDirname that works in CJS and ESM, since Alphalib is shared
-    // across both kinds of projects.
-    // We can remove this once we've migrated all consumers to ESM.
-    const { stack } = new Error()
-    if (!stack) {
-      throw new Error('Could not get stack')
+  static #modulePath() {
+    return {
+      dirpath: path.dirname(moduleFilepath),
+      filepath: moduleFilepath,
     }
-    const lines = stack.split('\n')
-
-    for (const line of lines) {
-      if (line.includes(' (/')) {
-        const location = line.split(' (')[1]
-        if (!location) {
-          throw new Error('Could not get location')
-        }
-        const filepath = location.split(':')[0]
-        if (!filepath) {
-          throw new Error('Could not get filepath')
-        }
-        const dirpath = path.dirname(filepath)
-        return { dirpath, filepath }
-      }
-    }
-
-    throw new Error('Could not get dirname')
   }
 
   static #getCallSite() {
@@ -238,7 +220,7 @@ export class SevLogger {
 
     const callSite = traces.find(
       (trace) =>
-        trace.filePath !== SevLogger.#pathFromStack().filepath &&
+        normalizeCallsitePath(trace.filePath ?? '') !== SevLogger.#modulePath().filepath &&
         trace.filePath &&
         basename(trace.filePath) !== `SevLogger.ts` &&
         basename(trace.filePath) !== `SevLogger.js` &&
@@ -1384,5 +1366,3 @@ export class SevLogger {
     })
   }
 }
-
-import { fileURLToPath } from 'node:url'


### PR DESCRIPTION
Why

A clean install of `@transloadit/sev-logger@1.0.0` could import the package, but actually logging with the default callsite formatter threw `Could not get dirname` when Node emitted `file://` ESM stack frames. This patch fixes the runtime path detection and releases `1.0.1`.

What changed

- Use the module's `import.meta.filename` as the logger's own file path instead of parsing it from a stack trace.
- Keep normalizing `file://` callsite paths before formatting them.
- Add a regression test that calls `notice()` with callsite detection enabled.
- Version `@transloadit/sev-logger` to `1.0.1` with a changelog entry.

Verification

- `corepack yarn install --immutable`
- `corepack yarn dedupe --check`
- `corepack yarn check`
- `corepack yarn npm audit --recursive --all`
- `git diff --check`
- Local built `dist` smoke test that imports `@transloadit/sev-logger` and calls `notice()`
