### PR TITLE
fix: avoid nodejs stream namespace leak

### DIFF
--- a/packages/sev-logger/CHANGELOG.md
+++ b/packages/sev-logger/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @transloadit/sev-logger
 
+## 1.0.2
+
+### Patch Changes
+
+- Avoid leaking the global NodeJS namespace from public stream types.
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/sev-logger/package.json
+++ b/packages/sev-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transloadit/sev-logger",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "repository": {
     "type": "git",
     "url": "git://github.com/transloadit/monolib.git",

--- a/packages/sev-logger/src/SevLogger.ts
+++ b/packages/sev-logger/src/SevLogger.ts
@@ -29,6 +29,12 @@ export interface SharedState {
   maxBreadcrumbLength: number
 }
 
+export interface SevLoggerStream {
+  columns?: number
+  isTTY?: boolean
+  write(chunk: string): unknown
+}
+
 export interface SevLoggerParams {
   /** Custom separator for nested breadcrumbs. Defaults to ':'. */
   nestDivider?: string
@@ -47,9 +53,9 @@ export interface SevLoggerParams {
   /** Make file paths clickable in standard formatted logs? Defaults based on env vars (usually true unless CI/production). See `LOG_CLICKABLES`, `NODE_ENV`, `CI`. */
   addClickables?: boolean
   /** Custom stream for standard output (levels NOTICE and below). Defaults to process.stdout. */
-  stdout?: NodeJS.WriteStream
+  stdout?: SevLoggerStream
   /** Custom stream for error output (levels WARN and above). Defaults to process.stderr. */
-  stderr?: NodeJS.WriteStream
+  stderr?: SevLoggerStream
   /** If set, logs will be appended to this file instead of stdout/stderr. */
   filepath?: string
   /** Shared state object for coordinating max prefix length across nested loggers. */
@@ -315,9 +321,9 @@ export class SevLogger {
 
   #params!: SevLoggerParams
 
-  stdout!: NodeJS.WriteStream
+  stdout!: SevLoggerStream
 
-  stderr!: NodeJS.WriteStream
+  stderr!: SevLoggerStream
 
   colors = {
     red: (s: string) => (process.env.NO_COLOR === '1' ? s : `\u001b[31m${s}\u001b[0m`),

--- a/packages/sev-logger/src/index.ts
+++ b/packages/sev-logger/src/index.ts
@@ -7,6 +7,7 @@ export type {
   SevLoggerParams,
   SevLoggerSpec,
   SevLoggerSpecType,
+  SevLoggerStream,
   SharedState,
 } from './SevLogger.ts'
 export { SevLogger } from './SevLogger.ts'


### PR DESCRIPTION
Why

The all-packages consumer smoke showed that runtime installs work, but `@transloadit/sev-logger` still leaked `NodeJS.WriteStream` through its public declarations. That makes TypeScript consumers depend on a global `NodeJS` namespace even when they only need the logger's stream contract.

What changed

- Added a structural `SevLoggerStream` interface for the logger's stdout/stderr options and properties.
- Exported `SevLoggerStream` from the package root.
- Versioned `@transloadit/sev-logger` to `1.0.2` with a changelog entry.

Verification

- `corepack yarn install --immutable`
- `corepack yarn dedupe --check`
- `corepack yarn check`
- `corepack yarn npm audit --recursive --all`
- `git diff --check`
- Local tarball TypeScript consumer smoke without `@types/node`
