### PR TITLE
fix: respect no color for inspected values

### DIFF
--- a/packages/sev-logger/CHANGELOG.md
+++ b/packages/sev-logger/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @transloadit/sev-logger
 
+## 1.0.3
+
+### Patch Changes
+
+- Respect `NO_COLOR=1` when formatting inspected object values.
+
 ## 1.0.2
 
 ### Patch Changes

--- a/packages/sev-logger/package.json
+++ b/packages/sev-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transloadit/sev-logger",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "repository": {
     "type": "git",
     "url": "git://github.com/transloadit/monolib.git",

--- a/packages/sev-logger/src/SevLogger.test.ts
+++ b/packages/sev-logger/src/SevLogger.test.ts
@@ -360,6 +360,28 @@ describe('SevLogger', () => {
       assert.match(output, /notice smoke ok/)
       assert.match(output, /SevLogger\.test\.(js|ts):\d+/)
     })
+
+    it('respects NO_COLOR for inspected objects', () => {
+      const previousNoColor = process.env.NO_COLOR
+      process.env.NO_COLOR = '1'
+      try {
+        const logger = new SevLogger({
+          level: LEVEL.TRACE,
+          addCallsite: false,
+        })
+
+        assert.strictEqual(
+          logger.formatter(LEVEL.NOTICE, { foo: 'bar' }),
+          "[ NOTICE] { foo: 'bar' }",
+        )
+      } finally {
+        if (previousNoColor === undefined) {
+          delete process.env.NO_COLOR
+        } else {
+          process.env.NO_COLOR = previousNoColor
+        }
+      }
+    })
   })
 
   describe('announceMotd', () => {

--- a/packages/sev-logger/src/SevLogger.ts
+++ b/packages/sev-logger/src/SevLogger.ts
@@ -412,6 +412,10 @@ export class SevLogger {
     this.reset(params)
   }
 
+  #inspect(value: unknown): string {
+    return inspect(value, false, null, process.env.NO_COLOR !== '1' && !this.filepath)
+  }
+
   colorByName(name: string) {
     const absCrc = SevLogger.#crc32(name)
 
@@ -923,7 +927,7 @@ export class SevLogger {
       const base = workingMessages.shift()
       if (typeof base !== 'string') {
         // Should not happen due to initial check, but safeguard
-        subject = inspect(base, false, null, true)
+        subject = this.#inspect(base)
       } else {
         // Perform replacement - Type errors inside callback WILL throw
         subject = base.replace(
@@ -947,7 +951,7 @@ export class SevLogger {
                 if (typeof arg === 'string' || typeof arg === 'number') {
                   return match.replace('%s', fmtColorFunc(String(arg)))
                 }
-                return match.replace('%s', inspect(arg, false, null, true)) // Use inspect for non-string/num %s
+                return match.replace('%s', this.#inspect(arg)) // Use inspect for non-string/num %s
               }
               if (match.includes('%r')) {
                 if (typeof arg !== 'string') {
@@ -982,7 +986,7 @@ export class SevLogger {
           console.error(`SevLogger Formatting Warning: ${errorMsg}`, originalMessages)
           // Fallback: Use original messages inspected
           subject = originalMessages
-            .map((msg) => (typeof msg === 'string' ? msg : inspect(msg, false, null, true)))
+            .map((msg) => (typeof msg === 'string' ? msg : this.#inspect(msg)))
             .join(' ')
           subject = subject.replace(/%%/g, '%') // Still handle escapes in the fallback
         }
@@ -990,7 +994,7 @@ export class SevLogger {
     } else {
       // No format specifiers or mismatch count, inspect all messages
       subject = redactedMessages
-        .map((msg) => (typeof msg === 'string' ? msg : inspect(msg, false, null, true)))
+        .map((msg) => (typeof msg === 'string' ? msg : this.#inspect(msg)))
         .join(' ')
       subject = subject.replace(/%%/g, '%')
     }


### PR DESCRIPTION
Why

Running the full `SevLogger.playground.ts` as an npm consumer from `/tmp/foo` worked, but showed one polish bug: `NO_COLOR=1` disabled logger colors while inspected object values still emitted ANSI escape codes.

What changed

- Route inspected non-string log values through the logger's color policy.
- Disable inspect colors for file output and `NO_COLOR=1`.
- Add a regression test for inspected object formatting under `NO_COLOR=1`.
- Version `@transloadit/sev-logger` to `1.0.3` with a changelog entry.

Verification

- `corepack yarn install --immutable`
- `corepack yarn dedupe --check`
- `corepack yarn check`
- `corepack yarn npm audit --recursive --all`
- `git diff --check`
- `/tmp/foo` npm-consumer playground run against `@transloadit/sev-logger@1.0.2` before the fix
