### PR TITLE
fix: route severe logs to stderr

### DIFF
--- a/packages/sev-logger/CHANGELOG.md
+++ b/packages/sev-logger/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @transloadit/sev-logger
 
+## 1.0.4
+
+### Patch Changes
+
+- Route warnings and errors to stderr while keeping notices and less severe logs on stdout.
+
 ## 1.0.3
 
 ### Patch Changes

--- a/packages/sev-logger/package.json
+++ b/packages/sev-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transloadit/sev-logger",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "repository": {
     "type": "git",
     "url": "git://github.com/transloadit/monolib.git",

--- a/packages/sev-logger/src/SevLogger.test.ts
+++ b/packages/sev-logger/src/SevLogger.test.ts
@@ -407,6 +407,52 @@ describe('SevLogger', () => {
     })
   })
 
+  describe('stream routing', () => {
+    it('routes warn and more severe logs to stderr', () => {
+      let stdout = ''
+      let stderr = ''
+      const stdoutStream = {
+        isTTY: false,
+        write: (chunk: string) => {
+          stdout += chunk
+          return true
+        },
+      }
+      const stderrStream = {
+        isTTY: false,
+        write: (chunk: string) => {
+          stderr += chunk
+          return true
+        },
+      }
+      const logger = new SevLogger({
+        level: LEVEL.TRACE,
+        addCallsite: false,
+        colors: plainColors,
+        levelColors: plainLevelColors,
+        formatColors: plainFormatColors,
+        stdout: stdoutStream,
+        stderr: stderrStream,
+      })
+
+      logger.warn('warn')
+      logger.err('err')
+      logger.notice('notice')
+      logger.info('info')
+      logger.debug('debug')
+      logger.event(LEVEL.WARN, { event: 'WARN_EVENT' })
+      logger.event(LEVEL.DEBUG, { event: 'DEBUG_EVENT' })
+
+      assert.match(stderr, /\[ {3}WARN\] warn/)
+      assert.match(stderr, /\[ {4}ERR\] err/)
+      assert.match(stderr, /WARN_EVENT/)
+      assert.match(stdout, /\[ NOTICE\] notice/)
+      assert.match(stdout, /\[ {3}INFO\] info/)
+      assert.match(stdout, /\[ {2}DEBUG\] debug/)
+      assert.match(stdout, /DEBUG_EVENT/)
+    })
+  })
+
   // Add a new describe block for type tests
   describe('Type Safety', () => {
     // Mock streams to capture output

--- a/packages/sev-logger/src/SevLogger.ts
+++ b/packages/sev-logger/src/SevLogger.ts
@@ -52,9 +52,9 @@ export interface SevLoggerParams {
   addCallsite?: boolean
   /** Make file paths clickable in standard formatted logs? Defaults based on env vars (usually true unless CI/production). See `LOG_CLICKABLES`, `NODE_ENV`, `CI`. */
   addClickables?: boolean
-  /** Custom stream for standard output (levels NOTICE and below). Defaults to process.stdout. */
+  /** Custom stream for standard/non-error output (NOTICE, INFO, DEBUG, TRACE). Defaults to process.stdout. */
   stdout?: SevLoggerStream
-  /** Custom stream for error output (levels WARN and above). Defaults to process.stderr. */
+  /** Custom stream for warnings and errors (WARN and more severe). Defaults to process.stderr. */
   stderr?: SevLoggerStream
   /** If set, logs will be appended to this file instead of stdout/stderr. */
   filepath?: string
@@ -414,6 +414,10 @@ export class SevLogger {
 
   #inspect(value: unknown): string {
     return inspect(value, false, null, process.env.NO_COLOR !== '1' && !this.filepath)
+  }
+
+  #streamFor(level: number): SevLoggerStream {
+    return level <= SevLogger.LEVEL.WARN ? this.stderr : this.stdout
   }
 
   colorByName(name: string) {
@@ -1066,7 +1070,7 @@ export class SevLogger {
       return
     }
     const fullStr = this.formatter(level, message, ...args)
-    const stream = level <= SevLogger.LEVEL.NOTICE ? this.stdout : this.stderr // NOTICE and below to stdout
+    const stream = this.#streamFor(level)
 
     if (this.filepath) {
       try {
@@ -1295,7 +1299,7 @@ export class SevLogger {
 
     // Join parts and write to stream
     const fullStr = parts.join(' ') // Simple space join for event format
-    const stream = level <= SevLogger.LEVEL.NOTICE ? this.stdout : this.stderr
+    const stream = this.#streamFor(level)
 
     if (this.filepath) {
       try {


### PR DESCRIPTION
Why

The full npm-consumer playground run from `/tmp/foo` showed that severe logs (`ALERT`/`CRIT`/`ERR`/`WARN`) were going to stdout while verbose logs went to stderr. That split does not match the stream option names or typical CLI behavior.

What changed

- Route `WARN` and more severe logs/events to stderr.
- Keep `NOTICE`, `INFO`, `DEBUG`, and `TRACE` on stdout.
- Clarify the public stream option comments.
- Add regression coverage for formatted log and event stream routing.
- Version `@transloadit/sev-logger` to `1.0.4` with a changelog entry.

Verification

- `corepack yarn install --immutable`
- `corepack yarn dedupe --check`
- `corepack yarn check`
- `corepack yarn npm audit --recursive --all`
- `git diff --check`
