### PR TITLE
Use GitHub Actions as release author

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,8 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}
-          git config --global user.name "transloadit-bot"
-          git config --global user.email "bot@transloadit.com"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Why: after removing transloadit-bot write access and bot PATs from this public repo, the release workflow should no longer leave public breadcrumbs that suggest the bot account is involved.

This changes the release workflow's git author identity to GitHub's built-in Actions bot. The workflow continues to use the built-in `github.token`; no release permissions or publishing behavior are changed.

Validation:
- `git diff --check`
- parsed `.github/workflows/release.yml` as YAML
- confirmed no `transloadit-bot`, `bot@transloadit.com`, or bot PAT strings remain in the workflow
