### PR TITLE
Use API commits for release PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       has-changesets: ${{ steps.changesets.outputs.has-changesets }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Detect pending changesets
         id: changesets
@@ -41,12 +41,12 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
 
@@ -64,6 +64,7 @@ jobs:
           version: corepack yarn changeset:version:install
           title: "chore: version packages"
           commit: "chore: version packages"
+          commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
@@ -80,12 +81,12 @@ jobs:
       NPM_TOKEN: ''
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
@@ -107,5 +108,6 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: corepack yarn release
+          commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Why

The release-test dependency PR proved that the split release workflow detects changesets correctly, but `changesets/action` failed when pushing `changeset-release/main`: the generated commit was made with git CLI mode and rejected by the org-wide verified-signature rule.

What changed

- Switches both Changesets action calls to `commitMode: github-api`, which the action documents as creating GPG-signed commits and tags owned by the token actor.
- Updates release-workflow checkout/setup-node actions from v4 to v6 to avoid the Node 20 action-runtime deprecation warning seen in the failed run.

Validation

- `git diff --check`
- Ruby YAML parse for `.github/workflows/release.yml`
- GitHub reports the pushed commit as verified

Follow-up test

After this lands, rerun the failed Release workflow or push another verified commit to `main`; it should create the Changesets version PR for `@transloadit/post` instead of failing on `GH013`.